### PR TITLE
Fix the conduit_server_manual example

### DIFF
--- a/conduit_server_manual/config.ml
+++ b/conduit_server_manual/config.ml
@@ -14,6 +14,6 @@ let socket =
   | `Unix -> [ handler $ c $ socket_stackv4 c [Ipaddr.V4.any] ]
 
 let () =
-  add_to_ocamlfind_libraries ["mirage-http"; "vchan"; "conduit.mirage-xen"];
+  add_to_ocamlfind_libraries ["mirage-http"; "vchan"];
   add_to_opam_packages ["mirage-http"; "vchan"];
   register "conduit_server" (direct :: socket)

--- a/conduit_server_manual/unikernel.ml
+++ b/conduit_server_manual/unikernel.ml
@@ -11,7 +11,7 @@ module Main (C:CONSOLE) (S:STACKV4) = struct
 
   module DNS = Dns_resolver_mirage.Make(OS.Time)(S)
   module RES = Resolver_mirage.Make(DNS)
-  module CON = Conduit_mirage.Make(S)(Conduit_xenstore)
+  module CON = Conduit_mirage.Make(S)(Conduit_localhost)
   module H   = HTTP.Make(CON)
 
   let start console s =


### PR DESCRIPTION
This now builds with the current mirage-xen dev packages.

Signed-off-by: David Scott dave.scott@eu.citrix.com
