### PR TITLE
Fix dns example by passing Io_page alloc to gethostbyname

### DIFF
--- a/dns/unikernel.ml
+++ b/dns/unikernel.ml
@@ -67,7 +67,8 @@ module Main (C:CONSOLE) (K:KV_RO) (S:STACKV4) = struct
       in
       let commfn = connect_to_resolver server port in
       let hostname = "dark.recoil.org" in
-      Dns_resolver.gethostbyname commfn hostname
+      let alloc () = Io_page.get 1 in
+      Dns_resolver.gethostbyname ~alloc commfn hostname
       >>= fun ips ->
       Lwt_list.iter_s (fun ip ->
        C.log_s c (sprintf "%s -> %s" hostname (Ipaddr.to_string ip))) ips


### PR DESCRIPTION
Prevents transmit from misaligned buffer
