### PR TITLE
passing "xvda1" to block_of_file for when using xen

### DIFF
--- a/block/config.ml
+++ b/block/config.ml
@@ -2,5 +2,8 @@ open Mirage
 
 let () =
   let main = foreign "Unikernel.Block_test" (console @-> block @-> job) in
-  let img = block_of_file "disk.img" in
+  let img =     
+    match get_mode () with
+    | `Xen -> block_of_file "xvda1"
+    | `Unix -> block_of_file "disk.img" in
   register "block_test" [main $ default_console $ img]


### PR DESCRIPTION
to workaround issue https://github.com/mirage/xen-arm-builder/issues/47, taken from @djs55 fix on http://lists.xenproject.org/archives/html/mirageos-devel/2015-01/msg00112.html.

This might need to be applied to the other examples that use block devices in this repo