### PR TITLE
Improvements to website example

### DIFF
--- a/static_website/README.md
+++ b/static_website/README.md
@@ -1,13 +1,15 @@
-Put static files into the htdocs/ directory.
-
 On Unix, do:
 
 ```
-$ env NET=socket FS=crunch mirage configure --unix
+$ env NET=socket mirage configure --unix
 $ make depend
 $ make
 $ make run
 ```
+
+This will run the website on localhost on port 8080, so you should be
+able to visit [http://localhost:8080](http://localhost:8080) and see the
+content from htdocs directory.
 
 For a Xen DHCP kernel, do:
 

--- a/static_website/config.ml
+++ b/static_website/config.ml
@@ -1,8 +1,8 @@
 open Mirage
 
-(* If the Unix `MODE` is set, the choice of configuration changes:
-   MODE=crunch (or nothing): use static filesystem via crunch
-   MODE=fat: use FAT and block device (run ./make-fat-images.sh)
+(* Use `FS` to set the underlying filesystem:
+   FS=crunch (or nothing): use static filesystem via crunch
+   FS=fat: use FAT and block device (run ./make-fat-images.sh)
  *)
 let mode =
   try match String.lowercase (Unix.getenv "FS") with

--- a/static_website/config.ml
+++ b/static_website/config.ml
@@ -41,7 +41,7 @@ let server =
   conduit_direct (stack default_console)
 
 let http_srv =
-  let mode = `TCP (`Port 80) in
+  let mode = `TCP (`Port 8080) in
   http_server mode server
 
 let main =


### PR DESCRIPTION
The main change here is to run the static_website example on an unpriviliged port, as previously it required root to run the examples. Prior to this change, if you run the README examples without being root you get the following running `make run`:

```
Manager: connect
Manager: configuring
Manager: socket config currently ignored (TODO)
Fatal error: exception Unix.Unix_error(Unix.EACCES, "bind", "")
Raised at file "src/core/lwt.ml", line 788, characters 22-23
Called from file "src/unix/lwt_main.ml", line 34, characters 8-18
Called from file "main.ml", line 85, characters 2-28
make: *** [run] Error 2
```