### PR TITLE
Specified shell for script

### DIFF
--- a/block/generate_disk_img.sh
+++ b/block/generate_disk_img.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 dd if=/dev/zero of=disk.img count=100000


### PR DESCRIPTION
On fish shell, this script doesn't work without a shell being specified. This way it works everywhere.