### PR TITLE
Add a tracing example.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing mirage-profile:https://github.com/mirage/mirage-profile.git#v0.6"
     - WITH_TRACING=1
   matrix:
     - OCAML_VERSION=4.01

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.01
-    POST_INSTALL_HOOK="make MODE=unix && make clean"
-  - OCAML_VERSION=4.01
-    UPDATE_GCC_BINUTILS=1
-    POST_INSTALL_HOOK="make MODE=xen  && make clean"
+  global:
+    - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - WITH_TRACING=1
+  matrix:
+    - OCAML_VERSION=4.01
+      POST_INSTALL_HOOK="make MODE=unix && make clean"
+    - OCAML_VERSION=4.01
+      UPDATE_GCC_BINUTILS=1
+      POST_INSTALL_HOOK="make MODE=xen  && make clean"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 TESTS = console network stackv4 ethifv4 io_page lwt ping static_website dns \
         conduit_server conduit_server_manual static_website_tls http-fetch dhcp
 
+
+ifdef WITH_TRACING
+TESTS += tracing
+endif
+
 CONFIGS = $(patsubst %, %-configure, $(TESTS))
 BUILDS  = $(patsubst %, %-build,     $(TESTS))
 RUNS    = $(patsubst %, %-run,       $(TESTS))

--- a/tracing/config.ml
+++ b/tracing/config.ml
@@ -1,0 +1,11 @@
+open Mirage
+
+let main = foreign "Unikernel.Main" (stackv4 @-> job)
+let stack console = direct_stackv4_with_default_ipv4 console tap0
+
+let tracing = mprof_trace ~size:1000000 ()
+
+let () =
+  register "example" ~tracing [
+    main $ stack default_console;
+  ]

--- a/tracing/unikernel.ml
+++ b/tracing/unikernel.ml
@@ -1,0 +1,22 @@
+open Lwt.Infix
+let target_ip = Ipaddr.V4.of_string_exn "10.0.0.1"
+
+module Main (S: V1_LWT.STACKV4) = struct
+  let buffer = Io_page.get 1 |> Io_page.to_cstruct
+
+  let start s =
+    let t = S.tcpv4 s in
+
+    S.TCPV4.create_connection t (target_ip, 7001) >>= function
+    | `Error _err -> failwith "Connection to port 7001 failed"
+    | `Ok flow ->
+
+    let payload = Cstruct.sub buffer 0 1 in
+    Cstruct.set_char payload 0 '!';
+
+    S.TCPV4.write flow payload >>= function
+    | `Error _ | `Eof -> assert false
+    | `Ok () ->
+
+    S.TCPV4.close flow
+end

--- a/tracing/unikernel.ml
+++ b/tracing/unikernel.ml
@@ -1,3 +1,7 @@
+(* This unikernel is based on tracing documentation:
+   https://mirage.io/wiki/profiling
+*)
+
 open Lwt.Infix
 let target_ip = Ipaddr.V4.of_string_exn "10.0.0.1"
 


### PR DESCRIPTION
This adds a tracing example, based on @talex5's [blog post](https://mirage.io/wiki/profiling).
On top of the documentation value, it also stresses the tracing code for mirage/functoria's CI.