### PR TITLE
Remove instructions to add mirage-dev remote to opam.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ Prerequisites
 - Install latest OPAM (at least 1.1.0), following instructions at
 <http://opam.ocaml.org/>
 
-- Add the Mirage 2.0 development repos from
-
-```
-    $ opam remote add mirage-dev git://github.com/mirage/mirage-dev
-```
-
 - Install the `mirage` package with OPAM, updating your package first if
 necessary:
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,12 @@ to use block or network devices.
 ### To clean up after building a unikernel:
 
     $ make clean
+
+Experimental Modules
+--------------------
+
+The unikernels in this repository can also be used as a test suite for Mirage.  The `master` branch should work with packages released in the main opam repository, and the `mirage-dev` branch will work with packages held in a staging repository for experimental Mirage packages.  To use the staging repository:
+
+    $ opam remote add mirage-dev git://github.com/mirage/mirage-dev
+
+Then upgrade packages and build the `mirage-dev` branch of mirage-skeleton.


### PR DESCRIPTION
mirage-dev is often home to experimental packages or staging packages,
and since remotes are not switch-specific it is likely bad advice to add
this remote.  It's no longer necessary to add this remote to get mirage 2.0 and hasn't been for some time.