### PR TITLE
Fix block example

### DIFF
--- a/block/README.md
+++ b/block/README.md
@@ -1,15 +1,17 @@
 This test assumes that a file `disk.img` exists to connect the block test to.
-
 Generate it on Unix using the `generate_disk_img.sh` script.
 
-On Xen, just attach a block device to the VM (but ensure that it's a scratch
-disk, as it will be overwritten by this test).  Below is an example xl file
-for Xen 4.2 (replace the file paths with your local versions):
+On Unix:
+```
+mirage configure
+make
+./mir-block_test
+```
 
+On Xen:
 ```
-name = 'block_test'
-kernel = '/home/avsm/src/git/avsm/mirage-skeleton/block/mir-block_test.xen'
-builder = 'linux'
-memory = 256
-disk = [ 'tap:aio:/home/avsm/src/git/avsm/mirage-skeleton/block/disk.img,xvda1,w']
+mirage configure --xen
+make
+sudo xl create -c block_test.xl
 ```
+

--- a/block/config.ml
+++ b/block/config.ml
@@ -2,10 +2,7 @@ open Mirage
 
 let main = foreign "Unikernel.Main" (console @-> block @-> job)
 
-let img =
-  if_impl Key.is_xen
-    (block_of_file "xvda1")
-    (block_of_file "disk.img")
+let img = block_of_file "disk.img"
 
 let () =
   register "block_test" [main $ default_console $ img]


### PR DESCRIPTION
`mirage` will now generate an example .xl file which contains the path
to the file image, and `xl` will take care of setting up loop devices
if necessary. Previously we had to do this by hand, which meant that
running the Xen example was more complicated than running the Unix example.

Now the unikernel config.ml is independent of whether the target build is
for Xen or Unix.

Fixes #114

Signed-off-by: David Scott <dave.scott@docker.com>