### PR TITLE
Clean up DNS example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing mirage-profile:https://github.com/mirage/mirage-profile.git#v0.6"
     - WITH_TRACING=1
   matrix:
-    - OCAML_VERSION=4.01
+    - OCAML_VERSION=4.02
       POST_INSTALL_HOOK="make MODE=unix && make clean"
-    - OCAML_VERSION=4.01
+    - OCAML_VERSION=4.02
       UPDATE_GCC_BINUTILS=1
       POST_INSTALL_HOOK="make MODE=xen  && make clean"

--- a/dns/README.md
+++ b/dns/README.md
@@ -1,0 +1,30 @@
+A simple DNS server that serves the static DNS data found in the `data/test.zone` file.
+
+It also behaves as a DNS client, resolving `dark.recoil.org`.
+
+To test under Unix:
+
+```
+$ mirage configure --unix --net=socket
+$ make
+$ sudo ./mir-dns
+Manager: connect
+Manager: configuring
+2016-03-12 12:27.40: INF [server] Loading 3107 bytes of zone data
+Warning (<string> line 47): Converting MD to MX
+Warning (<string> line 48): Converting MF to MX
+2016-03-12 12:27.40: INF [server] DNS server listening on UDP port 53
+2016-03-12 12:27.43: INF [client] Starting client resolver
+2016-03-12 12:27.43: INF [client] Got resolver response, length 49
+2016-03-12 12:27.43: INF [client] Got IPS: 89.16.177.154
+```
+
+You can test the server using `nslookup`, e.g.
+
+    $ nslookup mail.d1.signpo.st 127.0.0.1
+    Server:		127.0.0.1
+    Address:	127.0.0.1#53
+
+    Name:	mail.d1.signpo.st
+    Address: 127.0.0.94
+

--- a/dns/config.ml
+++ b/dns/config.ml
@@ -7,48 +7,13 @@ let data = crunch "./data"
     package, and it requires a logging console, a read-only
     key/value store and a TCP/IP stack. *)
 let dns_handler =
-  let libraries = ["dns.lwt-core"] in
-  let packages = ["dns"] in
+  let libraries = ["dns.lwt-core"; "mirage-logs"] in
+  let packages = ["dns"; "mirage-logs"] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (console @-> kv_ro @-> stackv4 @-> job)
+    "Unikernel.Main" (clock @-> kv_ro @-> stackv4 @-> job)
 
-(** Supply a default console and the data to the DNS handler.
-    It still requires a network stack to become a full [job] *)
-let dns_handler_with_data =
-  dns_handler $     
-  default_console $  (* Supply the default logging console *)
-  data               (* K/V store builtin to unikernel *)
-
-(** There are two ways of building this: with pure MirageOS
-    networking or with standard Unix kernel sockets.
-    We define a "direct" key to configure this at build time. *)
-let direct_net =
-  let doc = Key.Arg.info
-    ~doc:"use direct networking if $(i,true) or kernel sockets otherwise"
-    [ "direct" ]
-  in Key.(create "direct" Arg.(opt ~stage:`Configure bool true doc))
-
-(** [direct_job] defines a job that is the pure OCaml network implementation. *)
-let direct_job =
-  dns_handler_with_data $
-  (direct_stackv4_with_dhcp default_console tap0)
-  (* MirageOS TCP/IP stack *)
-
-(* [socket_job] defines a job that uses Unix kernel sockets. *)
-let socket_job =
-  if_impl Key.is_xen
-    noop  (* Do nothing with sockets if we are in Xen *) 
-    (dns_handler_with_data $
-     socket_stackv4 default_console [Ipaddr.V4.any]) 
-
-(* If the configuration [direct_net] key is true, pick the direct
-   networking stack, otherwise select the socket *)
-let net =
-  if_impl (Key.value direct_net)
-    direct_job
-    socket_job
+let stack = generic_stackv4 default_console tap0
 
 let () =
-  register "dns" [net]
-
+  register "dns" [dns_handler $ default_clock $ data $ stack]

--- a/dns/unikernel.ml
+++ b/dns/unikernel.ml
@@ -1,91 +1,105 @@
 open Lwt.Infix
-open V1_LWT
-open Printf
 
-let listening_port = 5354
+let client_src = Logs.Src.create "client" ~doc:"DNS client"
+module Client_log = (val Logs.src_log client_src : Logs.LOG)
 
-let red fmt    = sprintf ("\027[31m"^^fmt^^"\027[m")
-let green fmt  = sprintf ("\027[32m"^^fmt^^"\027[m")
-let yellow fmt = sprintf ("\027[33m"^^fmt^^"\027[m")
-let blue fmt   = sprintf ("\027[36m"^^fmt^^"\027[m")
+let server_src = Logs.Src.create "server" ~doc:"DNS server"
+module Server_log = (val Logs.src_log server_src : Logs.LOG)
 
-module Main (C:CONSOLE) (K:KV_RO) (S:STACKV4) = struct
+(* Settings for client test *)
+let server = "8.8.8.8"
+let port = 53
+let client_source_port = 7000
+let test_hostname = "dark.recoil.org"
+
+(* Server settings *)
+let listening_port = 53
+
+module Main (Clock:V1.CLOCK) (K:V1_LWT.KV_RO) (S:V1_LWT.STACKV4) = struct
+  module Logs_reporter = Mirage_logs.Make(Clock)
 
   module U = S.UDPV4
 
-  (** Note that a lot of this logic will eventually move into
-      a mirage-dns library, and is just here temporarily *)
-  let start c k s =
-    begin
-      K.size k "test.zone" >>= function
-      | `Error _ -> Lwt.fail (Failure "test.zone not found")
-      | `Ok sz ->
-        K.read k "test.zone" 0 (Int64.to_int sz)
-        >>= function
-        | `Error _  -> Lwt.fail (Failure "test.zone error reading")
-        | `Ok pages ->
-          Lwt.return (String.concat "" (List.map Cstruct.to_string pages))
-    end >>= fun zonebuf ->
+  let load_zone k =
+    K.size k "test.zone"
+    >>= function
+    | `Error _ -> Lwt.fail (Failure "test.zone not found")
+    | `Ok sz ->
+      Server_log.info (fun f -> f "Loading %Ld bytes of zone data" sz);
+      K.read k "test.zone" 0 (Int64.to_int sz)
+      >>= function
+      | `Error _ -> Lwt.fail (Failure "test.zone error reading")
+      | `Ok pages -> Lwt.return (Cstruct.concat pages |> Cstruct.to_string)
+
+  let connect_to_resolver stack server port : Dns_resolver.commfn =
+    let udp = S.udpv4 stack in
+    let dest_ip = Ipaddr.V4.of_string_exn server in
+    let txfn buf =
+      let buf = Cstruct.of_bigarray buf in
+      (* Cstruct.hexdump buf; *)
+      U.write ~source_port:client_source_port ~dest_ip ~dest_port:port udp buf in
+    let st, push_st = Lwt_stream.create () in
+    S.listen_udpv4 stack ~port:client_source_port (
+      fun ~src:_ ~dst:_ ~src_port:_ buf ->
+        Client_log.info (fun f -> f "Got resolver response, length %d" (Cstruct.len buf));
+        let ba = Cstruct.to_bigarray buf in
+        push_st (Some ba);
+        Lwt.return ()
+    );
+    let rec rxfn f =
+      Lwt_stream.get st
+      >>= function
+      | None     -> Lwt.fail (Failure "resolver flow closed")
+      | Some buf -> begin
+          match f buf with
+          | None   -> rxfn f
+          | Some r -> Lwt.return r
+        end
+    in
+    let timerfn () = OS.Time.sleep 5.0 in
+    let cleanfn () = Lwt.return () in
+    { Dns_resolver.txfn; rxfn; timerfn; cleanfn }
+
+  let make_client_request stack =
+    OS.Time.sleep 3.0 >>= fun () ->
+    Client_log.info (fun f -> f "Starting client resolver");
+    let commfn = connect_to_resolver stack server port in
+    let alloc () = (Io_page.get 1 :> Dns.Buf.t) in
+    Dns_resolver.gethostbyname ~alloc commfn test_hostname
+    >>= fun ips ->
+    Client_log.info (fun f -> f "Got IPS: %a" Format.(pp_print_list Ipaddr.pp_hum) ips);
+    Lwt.return ()
+
+  let serve s zonebuf =
     let open Dns_server in
     let process = process_of_zonebuf zonebuf in
     let processor = (processor_of_process process :> (module PROCESSOR)) in
     let udp = S.udpv4 s in
-    let _ =
-      let server = "8.8.8.8" in
-      let port = 53 in
-      let listening_port = 5359 in
-      OS.Time.sleep 3.0 >>= fun () ->
-      C.log_s c "Starting client resolver" >>= fun () ->
-      let connect_to_resolver server port : Dns_resolver.commfn =
-        let dest_ip = Ipaddr.V4.of_string_exn server in
-        let txfn buf =
-          let buf = Cstruct.of_bigarray buf in
-          Cstruct.hexdump buf;
-          U.write ~source_port:listening_port ~dest_ip ~dest_port:port udp buf in
-        let st, push_st = Lwt_stream.create () in
-        S.listen_udpv4 s ~port:listening_port (
-          fun ~src:_ ~dst:_ ~src_port:_ buf ->
-            C.log_s c (sprintf "resolver response, length %d" (Cstruct.len buf))
-            >>= fun () ->
-            let ba = Cstruct.to_bigarray buf in
-            push_st (Some ba);
-            Lwt.return_unit
-        );
-        let rec rxfn f =
-          Lwt_stream.get st >>= function
-          | None     -> Lwt.fail (Failure "resolver flow closed")
-          | Some buf -> begin
-              match f buf with
-              | None   -> rxfn f
-              | Some r -> Lwt.return r
-            end
-        in
-        let timerfn () = OS.Time.sleep 5.0 in
-        let cleanfn () = Lwt.return () in
-        { Dns_resolver.txfn; rxfn; timerfn; cleanfn }
-      in
-      let commfn = connect_to_resolver server port in
-      let hostname = "dark.recoil.org" in
-      let alloc () = (Io_page.get 1 :> Dns.Buf.t) in
-      Dns_resolver.gethostbyname ~alloc commfn hostname
-      >>= fun ips ->
-      Lwt_list.iter_s (fun ip ->
-       C.log_s c (sprintf "%s -> %s" hostname (Ipaddr.to_string ip))) ips
-    in
     S.listen_udpv4 s ~port:listening_port (
       fun ~src ~dst ~src_port buf ->
-        C.log_s c "got udp"
-        >>= fun () ->
+        Server_log.info (fun f -> f "Got DNS query via UDP");
         let ba = Cstruct.to_bigarray buf in
         let src' = (Ipaddr.V4 dst), listening_port in
         let dst' = (Ipaddr.V4 src), src_port in
         let obuf = (Io_page.get 1 :> Dns.Buf.t) in
         process_query ba (Dns.Buf.length ba) obuf src' dst' processor >>= function
         | None ->
-          C.log_s c "No response"
+          Server_log.info (fun f -> f "No response");
+          Lwt.return ()
         | Some rba ->
           let rbuf = Cstruct.of_bigarray rba in
+          Server_log.info (fun f -> f "Sending reply");
           U.write ~source_port:listening_port ~dest_ip:src ~dest_port:src_port udp rbuf
     );
+    Server_log.info (fun f -> f "DNS server listening on UDP port %d" listening_port);
     S.listen s
+
+  let start () kv_store stack =
+    Logs.(set_level (Some Info));
+    Logs_reporter.(create () |> run) @@ fun () ->
+    load_zone kv_store >>= fun zonebuf ->
+    Lwt.join [
+      serve stack zonebuf;
+      make_client_request stack
+    ]
 end


### PR DESCRIPTION
- Split the code into smaller functions.
- Use logging API instead of passing a console around.
- Add README.
- Replace network configuration with generic_stackv4 (allows running
  with the native stack too).
- Move hard-coded settings to top of file.
- Comment out confusing/unlabelled hexdump.
- Don't send client test from source port that the server is listening
  on.
- Listen on port 53 by default. If a non-default port is used,
  `nslookup` must be run in interactive mode and in this mode it gets
  `SERVFAIL` for some reason.