### PR TITLE
Run `mirage-configure` with --$MODE rather than -t $MODE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lwt-clean:
 
 ## default tests
 %-configure:
-	$(MIRAGE) configure -f $*/config.ml -t $(MODE) $(FLAGS)
+	$(MIRAGE) configure -f $*/config.ml --$(MODE) $(FLAGS)
 
 %-build: %-configure
 	cd $* && $(MAKE)

--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -8,7 +8,7 @@ build: $(patsubst %,%-build,$(TARGETS))
 clean: $(patsubst %,%-clean,$(TARGETS))
 
 %-build:
-	TARGET=$* $(MIRAGE) configure -f src/config.ml -t $(MODE) $(FLAGS)
+	TARGET=$* $(MIRAGE) configure -f src/config.ml --$(MODE) $(FLAGS)
 	TARGET=$* $(MIRAGE) build -f src/config.ml
 
 %-clean:


### PR DESCRIPTION
Signed-off-by: Mindy Preston <mindy.preston@docker.com>