### PR TITLE
Ask for two distinct network interfaces via key_gen

### DIFF
--- a/netif-forward/config.ml
+++ b/netif-forward/config.ml
@@ -4,5 +4,5 @@ let main = foreign "Unikernel.Main" (console @-> network @-> network @-> job)
 
 let () =
   register "network" [
-    main $ default_console $ (netif "1") $ (netif "2")
+    main $ default_console $ (netif "1") $ (netif ~group:"other" "2")
   ]


### PR DESCRIPTION
Per https://github.com/mirage/mirage/issues/481 , we need to override
the default key names in order to get distinct network interfaces.