### PR TITLE
Modernise DHCP

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,6 @@
 PKG lwt mirage mirage-types tcpip mirage-http conduit.mirage mirage-console
 PKG cohttp mirage-net-unix mirage-unix mirage-clock-unix functoria
-PKG tcpip.ethif tcpip.arpv4 tls logs mirage-logs
+PKG tcpip.ethif tcpip.arpv4 tls logs mirage-logs charrua-core
 PKG magic-mime
 S **/
 B **/_build/**

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,13 @@ CLEANS  = $(patsubst %, %-clean,     $(TESTS))
 all: build
 
 configure: $(CONFIGS)
-build: $(BUILDS) lwt-build
+build: $(BUILDS)
 testrun: $(TESTRUN)
-clean: $(CLEANS) lwt-clean
+clean: $(CLEANS)
 
 ## lwt special cased
-lwt: lwt-clean lwt-build
 lwt-configure:
-	@ :
+	$(MAKE) -C lwt configure
 
 lwt-build:
 	$(MAKE) -C lwt build
@@ -38,12 +37,12 @@ lwt-testrun:
 %-configure:
 	$(MIRAGE) configure -f $*/config.ml --$(MODE) $(MIRAGE_FLAGS)
 
-%-build: %-configure
+%-build:
 	cd $* && $(MAKE)
 
 %-clean:
 	$(MIRAGE) clean -f $*/config.ml
-	$(RM) log
+	cd $* && $(RM) log static*.mli
 
 %-testrun:
 	$(SUDO) sh ./testrun.sh $*

--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,17 @@ ifdef WITH_TRACING
 TESTS += tracing
 endif
 
-CONFIGS = $(patsubst %, %-configure, $(TESTS))
 BUILDS  = $(patsubst %, %-build,     $(TESTS))
 TESTRUN = $(patsubst %, %-testrun,   $(TESTS))
 CLEANS  = $(patsubst %, %-clean,     $(TESTS))
 
 all: build
 
-configure: $(CONFIGS)
 build: $(BUILDS)
 testrun: $(TESTRUN)
 clean: $(CLEANS)
 
 ## lwt special cased
-lwt-configure:
-	$(MAKE) -C lwt configure
-
 lwt-build:
 	$(MAKE) -C lwt build
 
@@ -34,10 +29,8 @@ lwt-testrun:
 	@ :
 
 ## default tests
-%-configure:
-	$(MIRAGE) configure -f $*/config.ml --$(MODE) $(MIRAGE_FLAGS)
-
 %-build:
+	$(MIRAGE) configure -f $*/config.ml --$(MODE) $(MIRAGE_FLAGS)
 	cd $* && $(MAKE)
 
 %-clean:

--- a/Makefile.config
+++ b/Makefile.config
@@ -1,6 +1,3 @@
-MIRAGE  = mirage
-
-MODE   ?= unix
-NET    ?= socket
-
+MIRAGE ?= mirage
+MODE ?= unix
 MIRAGE_FLAGS ?=

--- a/block/config.ml
+++ b/block/config.ml
@@ -17,10 +17,11 @@ let config_shell = impl @@ object
     method module_name = "Functoria_runtime"
     method name = "shell_config"
     method ty = shellconfig
-end
+  end
 
-
-let main = foreign ~deps:[abstract config_shell] "Unikernel.Main" (console @-> block @-> job)
+let main =
+  foreign ~deps:[abstract config_shell]
+    "Unikernel.Main" (console @-> block @-> job)
 
 let img = block_of_file "disk.img"
 

--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -1,13 +1,22 @@
 open Mirage
 
-let main = foreign "Unikernel.Main" (console @-> kv_ro @-> network @-> clock @-> job)
+let ipaddr =
+  let doc = Key.Arg.info ~doc:"Server IP address." ["ipaddr"] in
+  Key.(create "ipaddr" Arg.(opt string "192.168.1.5" doc))
 
-let disk = crunch "files"
+let disk = generic_kv_ro "files"
+
+let main =
+  let libraries = [
+    "charrua-core.server"; "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"
+  ] in
+  let packages = ["charrua-core"] in
+  let keys = [Key.abstract ipaddr] in
+  foreign ~libraries ~packages ~keys
+    "Unikernel.Main" (clock @-> kv_ro @-> network @-> job)
+
 
 let () =
-  add_to_ocamlfind_libraries ([ "charrua-core.server";
-                                "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"]);
-  add_to_opam_packages ["charrua-core"];
   register "dhcp" [
-    main $ default_console $ disk $ tap0 $ default_clock
+    main $ default_clock $ disk $ tap0
   ]

--- a/dhcp/unikernel.ml
+++ b/dhcp/unikernel.ml
@@ -1,73 +1,77 @@
-open V1_LWT
 open Lwt.Infix
 
+let server_src = Logs.Src.create "server" ~doc:"HTTP server"
+module Server_log = (val Logs.src_log server_src : Logs.LOG)
+
 (* IP Configuration, all you need besides dhcpd.conf. *)
-let ipaddr = Ipaddr.V4.of_string_exn "192.168.1.5"
-
-
-let red fmt    = Printf.sprintf ("\027[31m"^^fmt^^"\027[m")
-let green fmt  = Printf.sprintf ("\027[32m"^^fmt^^"\027[m")
-let yellow fmt = Printf.sprintf ("\027[33m"^^fmt^^"\027[m")
-let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
-
 let string_of_stream s =
   let s = List.map Cstruct.to_string s in
   (String.concat "" s)
 
-module Main (C: CONSOLE) (KV: KV_RO) (N: NETWORK) (Clock : V1.CLOCK) = struct
+module Main (Clock : V1.CLOCK) (KV: V1_LWT.KV_RO) (N: V1_LWT.NETWORK) = struct
+  module Logs_reporter = Mirage_logs.Make(Clock)
   module E = Ethif.Make(N)
   module A = Arpv4.Make(E)(Clock)(OS.Time)
-
-  let log c s =
-    Str.split_delim (Str.regexp "\n") s |>
-    List.iter (fun line -> C.log c line)
 
   let of_interest dest net =
     Macaddr.compare dest (N.mac net) = 0 || not (Macaddr.is_unicast dest)
 
-  let input_dhcp c net config leases buf =
-    let open Dhcp_server.Input in
+  let input_dhcp net config leases buf =
     match (Dhcp_wire.pkt_of_buf buf (Cstruct.len buf)) with
-    | `Error e -> log c (red "Can't parse packet: %s" e);
+    | `Error e ->
+      Server_log.warn (fun f -> f "Can't parse packet: %s" e);
       Lwt.return leases
     | `Ok pkt ->
+      let open Dhcp_server.Input in
       match (input_pkt config leases pkt (Clock.time ())) with
       | Silence -> Lwt.return leases
       | Update leases ->
-        log c (blue "Received packet %s - updated lease database" (Dhcp_wire.pkt_to_string pkt));
+        Server_log.info (fun f ->
+            let s = Dhcp_wire.pkt_to_string pkt in
+            f "Received packet %s - updated lease database" s
+          );
         Lwt.return leases
       | Warning w ->
-        log c (yellow "%s" w);
+        Server_log.warn (fun f -> f "%s" w);
         Lwt.return leases
       | Error e ->
-        log c (red "%s" e);
+        Server_log.err (fun f -> f "%s" e);
         Lwt.return leases
       | Reply (reply, leases) ->
-        log c (blue "Received packet %s" (Dhcp_wire.pkt_to_string pkt));
+        Server_log.info (fun f ->
+            let s = Dhcp_wire.pkt_to_string pkt in
+            f "Received packet %s" s
+          );
         N.write net (Dhcp_wire.buf_of_pkt reply)
         >>= fun () ->
-        log c (blue "Sent reply packet %s" (Dhcp_wire.pkt_to_string reply));
+        Server_log.info (fun f ->
+            f "Sent reply packet %s" (Dhcp_wire.pkt_to_string reply)
+          );
         Lwt.return leases
 
-  let start c kv net _ =
-    let or_error _c name fn t =
+  let start _clock kv net =
+    Logs.(set_level (Some Info));
+    Logs_reporter.(create () |> run) @@ fun () ->
+
+    let or_error name fn t =
       fn t >>= function
       | `Error _e -> Lwt.fail (Failure ("Error starting " ^ name))
       | `Ok t     -> Lwt.return t
     in
+    let ipaddr = Key_gen.ipaddr () |> Ipaddr.V4.of_string_exn in
+
     (* Read the config file *)
-    or_error c "Kv.size" (KV.size kv) "dhcpd.conf"
+    or_error "Kv.size" (KV.size kv) "dhcpd.conf"
     >>= fun size ->
-    or_error c "Kv.read" (KV.read kv "dhcpd.conf" 0) (Int64.to_int size)
+    or_error "Kv.read" (KV.read kv "dhcpd.conf" 0) (Int64.to_int size)
     >>= fun v -> Lwt.return (string_of_stream v)
     >>= fun conf ->
-    log c (green "Using configuration:");
-    log c (green "%s" conf);
+    Server_log.info (fun f -> f "Using configuration:\n%s" conf);
 
     (* Get an ARP stack *)
-    or_error c "Ethif" E.connect net
+    or_error "Ethif" E.connect net
     >>= fun e ->
-    or_error c "Arpv4" A.connect e
+    or_error "Arpv4" A.connect e
     >>= fun a ->
     A.add_ip a ipaddr
     >>= fun () ->
@@ -82,7 +86,7 @@ module Main (C: CONSOLE) (KV: KV_RO) (N: NETWORK) (Clock : V1.CLOCK) = struct
            | Some Wire_structs.ARP -> A.input a payload
            | Some Wire_structs.IPv4 ->
              if Dhcp_wire.is_dhcp buf (Cstruct.len buf) then
-               input_dhcp c net config !leases buf >>= fun new_leases ->
+               input_dhcp net config !leases buf >>= fun new_leases ->
                leases := new_leases;
                Lwt.return_unit
              else

--- a/dhcp/unikernel.ml
+++ b/dhcp/unikernel.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-let server_src = Logs.Src.create "server" ~doc:"HTTP server"
+let server_src = Logs.Src.create "server" ~doc:"DHCP server"
 module Server_log = (val Logs.src_log server_src : Logs.LOG)
 
 (* IP Configuration, all you need besides dhcpd.conf. *)

--- a/dns/README.md
+++ b/dns/README.md
@@ -27,4 +27,3 @@ You can test the server using `nslookup`, e.g.
 
     Name:	mail.d1.signpo.st
     Address: 127.0.0.94
-

--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -1,14 +1,19 @@
 include ../Makefile.config
 
-TARGETS=heads1 heads2 heads3 timeout1 timeout2 echo_server1
+CP ?= cp -av
+TARGETS = heads1 heads2 heads3 timeout1 timeout2 echo_server1
 
-configure: $(patsubst %,%-configure,$(TARGETS))
+configure:
+	@ :
 build: $(patsubst %,%-build,$(TARGETS))
 clean: $(patsubst %,%-clean,$(TARGETS))
 
+%-configure:
+	@ :
+
 %-build:
 	TARGET=$* $(MIRAGE) configure -f src/config.ml --$(MODE) $(MIRAGE_FLAGS)
-	TARGET=$* $(MIRAGE) build -f src/config.ml
+	cd src && $(MAKE) && $(RM) mir-$* && $(CP) _build/main.native mir-$*
 
 %-clean:
 	TARGET=$* $(MIRAGE) clean -f src/config.ml

--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -8,7 +8,7 @@ clean: $(patsubst %,%-clean,$(TARGETS))
 
 %-build:
 	TARGET=$* $(MIRAGE) configure -f src/config.ml --$(MODE) $(MIRAGE_FLAGS)
-	cd src && $(MAKE) && $(RM) mir-$* && $(CP) _build/main.native mir-$*
+	cd src && $(MAKE)
 
 %-clean:
 	TARGET=$* $(MIRAGE) clean -f src/config.ml

--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -3,13 +3,8 @@ include ../Makefile.config
 CP ?= cp -av
 TARGETS = heads1 heads2 heads3 timeout1 timeout2 echo_server1
 
-configure:
-	@ :
 build: $(patsubst %,%-build,$(TARGETS))
 clean: $(patsubst %,%-clean,$(TARGETS))
-
-%-configure:
-	@ :
 
 %-build:
 	TARGET=$* $(MIRAGE) configure -f src/config.ml --$(MODE) $(MIRAGE_FLAGS)


### PR DESCRIPTION
* logging
* `ipaddr` as a key

Not thoroughly tested, but builds and runs and I don't think I changed any logic.

Also sanitises `make` rules for `lwt` which had rotted slightly.