### PR TITLE
remove call to `crunch files`

### DIFF
--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -2,8 +2,6 @@ open Mirage
 
 let main = foreign "Unikernel.Main" (console @-> network @-> clock @-> job)
 
-let disk = crunch "files"
-
 let () =
   add_to_ocamlfind_libraries ([ "charrua-core.server";
                                 "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"]);


### PR DESCRIPTION
A KV_RO is no longer used in the DHCP examples, so don't try to make one via `crunch`.