### PR TITLE
replace OS.Time calls with proper functorized Time

### DIFF
--- a/block/config.ml
+++ b/block/config.ml
@@ -20,9 +20,9 @@ let config_shell = impl @@ object
 end
 
 
-let main = foreign ~deps:[abstract config_shell] "Unikernel.Main" (block @-> job)
+let main = foreign ~deps:[abstract config_shell] "Unikernel.Main" (time @-> block @-> job)
 
 let img = block_of_file "disk.img"
 
 let () =
-  register "block_test" [main $ img]
+  register "block_test" [main $ default_time $ img]

--- a/block/unikernel.ml
+++ b/block/unikernel.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 open Printf
 open V1_LWT
 
-module Main (B: BLOCK) = struct
+module Main (Time: TIME)(B: BLOCK) = struct
 
   let tests_started = ref 0
   let tests_passed = ref 0
@@ -91,7 +91,7 @@ module Main (B: BLOCK) = struct
     | `Error _ ->
       incr tests_passed
 
-  let start b () =
+  let start _time b () =
     B.get_info b >>= fun info ->
     printf "sectors = %Ld\nread_write=%b\nsector_size=%d\n%!"
       info.B.size_sectors info.B.read_write info.B.sector_size;
@@ -123,6 +123,6 @@ module Main (B: BLOCK) = struct
     printf "Total tests started: %d\n" !tests_started;
     printf "Total tests passed:  %d\n" !tests_passed;
     printf "Total tests failed:  %d\n%!" !tests_failed;
-    OS.Time.sleep 5.
+    Time.sleep 5.
 
 end

--- a/conduit_server_manual/config.ml
+++ b/conduit_server_manual/config.ml
@@ -6,18 +6,18 @@ let handler =
   foreign
     ~libraries ~packages
     ~deps:[abstract nocrypto]
-    "Unikernel.Main" (console @-> stackv4 @-> job)
+    "Unikernel.Main" (time @-> console @-> stackv4 @-> job)
 
 let direct =
   let stack = direct_stackv4_with_default_ipv4 default_console tap0 in
-  handler $ default_console $ stack
+  handler $ default_time $ default_console $ stack
 
 (* Only add the Unix socket backend if the configuration mode is Unix *)
 let socket =
   let c = default_console in
   if_impl Key.is_xen
     noop
-    (handler $ c $ socket_stackv4 c [Ipaddr.V4.any])
+    (handler $ default_time $ c $ socket_stackv4 c [Ipaddr.V4.any])
 
 let () =
   register "conduit_server" [direct ; socket]

--- a/conduit_server_manual/unikernel.ml
+++ b/conduit_server_manual/unikernel.ml
@@ -7,16 +7,16 @@ let green fmt  = sprintf ("\027[32m"^^fmt^^"\027[m")
 let yellow fmt = sprintf ("\027[33m"^^fmt^^"\027[m")
 let blue fmt   = sprintf ("\027[36m"^^fmt^^"\027[m")
 
-module Main (C:CONSOLE) (S:STACKV4) = struct
+module Main (Time:TIME) (C:CONSOLE) (S:STACKV4) = struct
 
-  module DNS = Dns_resolver_mirage.Make(OS.Time)(S)
+  module DNS = Dns_resolver_mirage.Make(Time)(S)
   module RES = Resolver_mirage.Make(DNS)
   module H   = Cohttp_mirage.Server(Conduit_mirage.Flow)
 
   let conduit = Conduit_mirage.empty
   let stackv4 = Conduit_mirage.stackv4 (module S)
 
-  let start console s () =
+  let start _time console s () =
 
     C.log_s console (sprintf "IP address: %s\n"
       (String.concat ", " (List.map Ipaddr.V4.to_string (S.IPV4.get_ip (S.ipv4 s)))))

--- a/console/unikernel.ml
+++ b/console/unikernel.ml
@@ -1,13 +1,13 @@
 open Lwt.Infix
 
-module Main (C: V1_LWT.CONSOLE) = struct
+module Main (C: V1_LWT.CONSOLE) (T: V1_LWT.TIME) = struct
 
   let start c =
     let rec loop = function
       | 0 -> Lwt.return_unit
       | n ->
         C.log_s c "hello" >>= fun () ->
-        OS.Time.sleep 1.0 >>= fun () ->
+        Time.sleep 1.0 >>= fun () ->
         C.log_s c "world" >>= fun () ->
         loop (n-1)
     in

--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -1,11 +1,11 @@
 open Mirage
 
-let main = foreign "Unikernel.Main" (console @-> network @-> clock @-> job)
+let main = foreign "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
 
 let () =
   add_to_ocamlfind_libraries ([ "charrua-core.server";
                                 "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"]);
   add_to_opam_packages ["charrua-core"];
   register "dhcp" [
-    main $ default_console $ tap0 $ default_clock
+    main $ default_console $ tap0 $ default_clock $ default_time
   ]

--- a/dhcp/unikernel.ml
+++ b/dhcp/unikernel.ml
@@ -10,9 +10,9 @@ let string_of_stream s =
   let s = List.map Cstruct.to_string s in
   (String.concat "" s)
 
-module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) = struct
+module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) (Time: TIME) = struct
   module E = Ethif.Make(N)
-  module A = Arpv4.Make(E)(Clock)(OS.Time)
+  module A = Arpv4.Make(E)(Clock)(Time)
   module DC = Dhcp_config
 
   let log c s =
@@ -46,7 +46,7 @@ module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) = struct
         log c (blue "Sent reply packet %s" (Dhcp_wire.pkt_to_string reply));
         Lwt.return leases
 
-  let start c net _ =
+  let start c net _clock _time =
     let or_error _c name fn t =
       fn t >>= function
       | `Error _e -> Lwt.fail (Failure ("Error starting " ^ name))

--- a/ethifv4/config.ml
+++ b/ethifv4/config.ml
@@ -7,9 +7,9 @@ let main =
   let packages = ["tcpip"] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (console @-> network @-> clock @-> job)
+    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
 
 let () =
   register "ethifv4" [
-    main $ default_console $ tap0 $ default_clock
+    main $ default_console $ tap0 $ default_clock $ default_time
   ]

--- a/ethifv4/unikernel.ml
+++ b/ethifv4/unikernel.ml
@@ -6,14 +6,14 @@ let green fmt  = Printf.sprintf ("\027[32m"^^fmt^^"\027[m")
 let yellow fmt = Printf.sprintf ("\027[33m"^^fmt^^"\027[m")
 let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
 
-module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) = struct
+module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) (Time: TIME) = struct
 
   module E = Ethif.Make(N)
-  module A = Arpv4.Make(E)(Clock)(OS.Time)
+  module A = Arpv4.Make(E)(Clock)(Time)
   module I = Ipv4.Make(E)(A)
   module U = Udp.Make(I)
-  module T = Tcp.Flow.Make(I)(OS.Time)(Clock)(Random)
-  module D = Dhcp_clientv4.Make(C)(OS.Time)(Random)(U)
+  module T = Tcp.Flow.Make(I)(Time)(Clock)(Random)
+  module D = Dhcp_clientv4.Make(C)(Time)(Random)(U)
 
   let or_error _c name fn t =
     fn t
@@ -21,7 +21,7 @@ module Main (C: CONSOLE) (N: NETWORK) (Clock : V1.CLOCK) = struct
     | `Error _e -> Lwt.fail (Failure ("Error starting " ^ name))
     | `Ok t -> Lwt.return t
 
-  let start c net _ =
+  let start c net _clock _time =
     or_error c "Ethif" E.connect net
     >>= fun e ->
     or_error c "Arpv4" A.connect e

--- a/hello/config.ml
+++ b/hello/config.ml
@@ -7,7 +7,7 @@ let key =
 let main =
   foreign
     ~keys:[Key.abstract key]
-    "Unikernel.Main" (console @-> job)
+    "Unikernel.Main" (time @-> console @-> job)
 
 let () =
-  register "console" [main $ default_console]
+  register "console" [main $ default_time $ default_console]

--- a/hello/unikernel.ml
+++ b/hello/unikernel.ml
@@ -1,13 +1,13 @@
 open Lwt
 
-module Main (C: V1_LWT.CONSOLE) = struct
+module Main (C: V1_LWT.CONSOLE) (Time : V1_LWT.TIME) = struct
 
   let start c =
     let rec loop = function
       | 0 -> Lwt.return_unit
       | n ->
         C.log c (Key_gen.hello ());
-        OS.Time.sleep 1.0 >>= fun () ->
+        Time.sleep 1.0 >>= fun () ->
         loop (n-1)
     in
     loop 4

--- a/http-fetch/config.ml
+++ b/http-fetch/config.ml
@@ -7,11 +7,11 @@ let client =
   let packages = [ "mirage-http" ] in
   foreign
     ~libraries ~packages
-    "Unikernel.Client" @@ console @-> resolver @-> conduit @-> job
+    "Unikernel.Client" @@ time @-> console @-> resolver @-> conduit @-> job
 
 let () =
   let sv4 = stack default_console in
   let res_dns = resolver_dns sv4 in
   let conduit = conduit_direct sv4 in
-  let job =  [ client $ default_console $ res_dns $ conduit ] in
+  let job =  [ client $ default_time $ default_console $ res_dns $ conduit ] in
   register "http-fetch" job

--- a/http-fetch/unikernel.ml
+++ b/http-fetch/unikernel.ml
@@ -11,7 +11,7 @@ let domain = "anil.recoil.org"
 let uri = Uri.of_string "http://anil.recoil.org"
 let ns = "8.8.8.8"
 
-module Client (C: CONSOLE) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) = struct
+module Client (T: TIME) (C: CONSOLE) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) = struct
 
   let http_fetch c resolver ctx =
     C.log_s c (sprintf "Fetching %s with Cohttp:" (Uri.to_string uri))
@@ -45,7 +45,7 @@ module Client (C: CONSOLE) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) = struc
       | `Ok buf -> C.log_s c (sprintf "OK\n%s\n" (Cstruct.to_string buf))
     end
 
-  let start c res (ctx:CON.t) =
+  let start _time c res (ctx:CON.t) =
     C.log_s c (sprintf "Resolving in 1s using DNS server %s" ns) >>= fun () ->
     OS.Time.sleep 1.0 >>= fun () ->
     http_fetch c res ctx >>= fun () ->

--- a/io_page/config.ml
+++ b/io_page/config.ml
@@ -1,7 +1,7 @@
 open Mirage
 
-let main = foreign "Unikernel.Main" (console @-> job)
+let main = foreign "Unikernel.Main" (time @-> console @-> job)
 
 let () = register "io_page" [
-  main $ default_console
+  main $ default_time $ default_console
 ]

--- a/io_page/unikernel.ml
+++ b/io_page/unikernel.ml
@@ -4,7 +4,7 @@ module P = Io_page
 
 let sp = Printf.sprintf
 
-module Main (C: V1_LWT.CONSOLE) = struct
+module Main (Time: V1_LWT.TIME) (C: V1_LWT.CONSOLE) = struct
 
   let start c =
     let one_page = P.get 1 in
@@ -17,7 +17,7 @@ module Main (C: V1_LWT.CONSOLE) = struct
     P.string_blit "Hello world!" 0 one_page 0 12;
     Cstruct.hexdump cstruct_first_100bytes;
     C.log_s c (String.sub (P.to_string one_page) 0 12) >>= fun () ->
-    OS.Time.sleep 2.0
+    Time.sleep 2.0
 
 
 end

--- a/kv_ro_crunch/config.ml
+++ b/kv_ro_crunch/config.ml
@@ -1,10 +1,10 @@
 open Mirage
 
 let main =
-  foreign "Unikernel.Main" (console @-> kv_ro @-> kv_ro @-> job)
+  foreign "Unikernel.Main" (time @-> console @-> kv_ro @-> kv_ro @-> job)
 
 let disk1 = crunch "t"
 let disk2 = crunch "t"
 
 let () =
-  register "kv_ro" [main $ default_console $ disk1 $ disk2]
+  register "kv_ro" [main $ default_time $ default_console $ disk1 $ disk2]

--- a/kv_ro_crunch/unikernel.ml
+++ b/kv_ro_crunch/unikernel.ml
@@ -5,9 +5,9 @@ let string_of_stream s =
   let s = List.map Cstruct.to_string s in
   return (String.concat "" s)
 
-module Main (C: CONSOLE) (X: KV_RO) (Y: KV_RO) = struct
+module Main (Time: TIME) (C: CONSOLE) (X: KV_RO) (Y: KV_RO) = struct
 
-  let start c x y =
+  let start _time c x y =
     let rec aux () =
       X.read x "a" 0 4096
       >>= fun vx ->
@@ -27,7 +27,7 @@ module Main (C: CONSOLE) (X: KV_RO) (Y: KV_RO) = struct
           C.log_s c "NO! NO!"
       end
       >>= fun () ->
-      OS.Time.sleep 1.
+      Time.sleep 1.
       >>= aux
     in
     aux ()

--- a/ping/config.ml
+++ b/ping/config.ml
@@ -5,7 +5,7 @@ let main =
   let libraries = [ "tcpip.arpv4"; "tcpip.ethif"; "tcpip.ipv4" ] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (console @-> network @-> clock @-> job)
+    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
 
 let () =
-  register "ping" [ main $ default_console $ tap0 $ default_clock ]
+  register "ping" [ main $ default_console $ tap0 $ default_clock $ default_time ]

--- a/ping/unikernel.ml
+++ b/ping/unikernel.ml
@@ -10,10 +10,10 @@ let ipaddr   = "10.0.0.2"
 let netmask  = "255.255.255.0"
 let gateways = ["10.0.0.1"]
 
-module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.CLOCK) = struct
+module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.CLOCK) (Time: V1_LWT.TIME) = struct
 
   module E = Ethif.Make(N)
-  module A = Arpv4.Make(E)(Clock)(OS.Time)
+  module A = Arpv4.Make(E)(Clock)(Time)
   module I = Ipv4.Make(E)(A)
 
   let or_error _c name fn t =
@@ -22,7 +22,7 @@ module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.CLOCK) = struct
     | `Error _e -> Lwt.fail (Failure ("Error starting " ^ name))
     | `Ok t     -> Lwt.return t
 
-  let start c n _ =
+  let start c n _clock _time =
     C.log c (green "starting...");
     or_error c "Ethif" E.connect n >>= fun e ->
     or_error c "Arpv4" A.connect e >>= fun a ->

--- a/ping6/config.ml
+++ b/ping6/config.ml
@@ -5,7 +5,7 @@ let main =
   let libraries = [ "tcpip.ethif"; "tcpip.ipv6" ] in
   foreign
     ~packages ~libraries
-    "Unikernel.Main" (console @-> network @-> clock @-> job)
+    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
 
 let () =
-  register "ping" [ main $ default_console $ tap0 $ default_clock ]
+  register "ping" [ main $ default_console $ tap0 $ default_clock $ default_time ]

--- a/ping6/unikernel.ml
+++ b/ping6/unikernel.ml
@@ -9,10 +9,10 @@ let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
 let ipaddr   = "fc00::2"
 let gateways = ["fc00::1"]
 
-module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.CLOCK) = struct
+module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.CLOCK) (Time : TIME) = struct
 
   module E = Ethif.Make(N)
-  module I = Ipv6.Make(E)(OS.Time)(Clock)
+  module I = Ipv6.Make(E)(Time)(Clock)
 
   let or_error c name fn t =
     fn t
@@ -20,7 +20,7 @@ module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.CLOCK) = struct
     | `Error e -> fail (Failure ("Error starting " ^ name))
     | `Ok t -> return t
 
-  let start c n _ =
+  let start c n _clock _time =
     C.log c (green "starting...");
     or_error c "Ethif" E.connect n >>= fun e ->
     or_error c "Ipv6"  I.connect e >>= fun i ->


### PR DESCRIPTION
A number of our examples call `OS.Time`.  `OS` is in scope because we link in one of the libraries of `mirage-platform` and so this compiles, but the dependency on `Time` hasn't been properly stated or exposed when we do this.

Where we call `Time.sleep`, explicitly pass the `time` module to `foreign` and the `default_time` impl to `register` in the configuration file, and take a `Time` module argument in `unikernel.Main` and `_time` argument to `start`.