### PR TITLE
Fix examples to build against Mirage master

### DIFF
--- a/stackv4/config.ml
+++ b/stackv4/config.ml
@@ -2,7 +2,7 @@ open Mirage
 
 let handler = foreign "Unikernel.Main" (console @-> stackv4 @-> job)
 
-let stack = generic_stackv4 default_console tap0
+let stack = generic_stackv4 tap0
 
 let () =
   register "stackv4" [handler $ default_console $ stack]

--- a/stackv4/unikernel.ml
+++ b/stackv4/unikernel.ml
@@ -30,7 +30,7 @@ module Main (C:CONSOLE) (S:STACKV4) = struct
     let local_port = 8080 in
     S.listen_tcpv4 s ~port:local_port (
       fun flow ->
-        let remote, remote_port = T.get_dest flow in
+        let remote, remote_port = T.dst flow in
         C.log_s console
           (green "TCP %s:%d > _:%d"
              (Ipaddr.V4.to_string remote) remote_port local_port)

--- a/static_website/config.ml
+++ b/static_website/config.ml
@@ -1,6 +1,6 @@
 open Mirage
 
-let stack = generic_stackv4 default_console tap0
+let stack = generic_stackv4 tap0
 let data = generic_kv_ro "htdocs"
 let http_srv = http_server @@ conduit_direct ~tls:false stack
 

--- a/static_website_tls/config.ml
+++ b/static_website_tls/config.ml
@@ -1,6 +1,6 @@
 open Mirage
 
-let stack = generic_stackv4 default_console tap0
+let stack = generic_stackv4 tap0
 let data = generic_kv_ro "htdocs"
 let https_srv = http_server @@ conduit_direct ~tls:true stack
 


### PR DESCRIPTION
Update some more examples to build against current master:

- stackv4, static_website, static_website_tls: generic_stackv4 no longer takes a console argument
- stackv4: T.get_dest -> T.dst