### PR TITLE
New clock api

### DIFF
--- a/clock/config.ml
+++ b/clock/config.ml
@@ -1,0 +1,7 @@
+open Mirage
+
+let main =
+  foreign "Unikernel.Main" (console @-> pclock @-> job)
+
+let () =
+  register "speaking_clock" [ main $ default_console $ default_posix_clock ]

--- a/clock/config.ml
+++ b/clock/config.ml
@@ -1,7 +1,7 @@
 open Mirage
 
 let main =
-  foreign "Unikernel.Main" (console @-> pclock @-> mclock @-> job)
+  foreign "Unikernel.Main" (console @-> time @-> pclock @-> mclock @-> job)
 
 let () =
-  register "speaking_clock" [ main $ default_console $ default_posix_clock $ default_monotonic_clock ]
+  register "speaking_clock" [ main $ default_console $ default_time $ default_posix_clock $ default_monotonic_clock ]

--- a/clock/config.ml
+++ b/clock/config.ml
@@ -1,7 +1,7 @@
 open Mirage
 
 let main =
-  foreign "Unikernel.Main" (console @-> pclock @-> job)
+  foreign "Unikernel.Main" (console @-> pclock @-> mclock @-> job)
 
 let () =
-  register "speaking_clock" [ main $ default_console $ default_posix_clock ]
+  register "speaking_clock" [ main $ default_console $ default_posix_clock $ default_monotonic_clock ]

--- a/clock/unikernel.ml
+++ b/clock/unikernel.ml
@@ -1,12 +1,12 @@
-module Main (Console : V1_LWT.CONSOLE) (PClock : V1_LWT.PCLOCK) = struct
+module Main (Console : V1_LWT.CONSOLE) (PClock : V1_LWT.PCLOCK) (MClock : V1_LWT.MCLOCK) = struct
   let str_of_time (posix_time, timezone) =
     Format.asprintf "%a" (Ptime.pp_human ?tz_offset_s:timezone ()) posix_time
 
-  let start console pclock =
+  let start console pclock mclock =
     let rec speak () =
       let time = PClock.now_d_ps pclock |> Ptime.v in
       let tz = PClock.current_tz_offset_s pclock in
-      Console.log console (Printf.sprintf "At the chime, the time will be %s. \b" @@ str_of_time (time, tz));
+      Console.log console (Printf.sprintf "%Lu nanoseconds have elapsed. At the chime, the time will be %s. \b *DING*" (Mclock.elapsed_ns mclock) @@ str_of_time (time, tz));
       speak ()
     in
     speak ()

--- a/clock/unikernel.ml
+++ b/clock/unikernel.ml
@@ -1,0 +1,13 @@
+module Main (Console : V1_LWT.CONSOLE) (PClock : V1_LWT.PCLOCK) = struct
+  let str_of_time (posix_time, timezone) =
+    Format.asprintf "%a" (Ptime.pp_human ?tz_offset_s:timezone ()) posix_time
+
+  let start console pclock =
+    let rec speak () =
+      let time = PClock.now_d_ps pclock |> Ptime.v in
+      let tz = PClock.current_tz_offset_s pclock in
+      Console.log console (Printf.sprintf "At the chime, the time will be %s. \b" @@ str_of_time (time, tz));
+      speak ()
+    in
+    speak ()
+end

--- a/clock/unikernel.ml
+++ b/clock/unikernel.ml
@@ -1,13 +1,14 @@
-module Main (Console : V1_LWT.CONSOLE) (PClock : V1_LWT.PCLOCK) (MClock : V1_LWT.MCLOCK) = struct
+module Main (Console : V1_LWT.CONSOLE) (Time : V1_LWT.TIME) (PClock : V1_LWT.PCLOCK) (MClock : V1_LWT.MCLOCK) = struct
   let str_of_time (posix_time, timezone) =
     Format.asprintf "%a" (Ptime.pp_human ?tz_offset_s:timezone ()) posix_time
 
-  let start console pclock mclock =
-    let rec speak () =
-      let time = PClock.now_d_ps pclock |> Ptime.v in
+  let start console _ pclock mclock =
+    let (>>=) = Lwt.bind in
+    let rec speak pclock mclock () =
+      let current_time = PClock.now_d_ps pclock |> Ptime.v in
       let tz = PClock.current_tz_offset_s pclock in
-      Console.log console (Printf.sprintf "%Lu nanoseconds have elapsed. At the chime, the time will be %s. \b *DING*" (Mclock.elapsed_ns mclock) @@ str_of_time (time, tz));
-      speak ()
+      Console.log console (Printf.sprintf "%Lu nanoseconds have elapsed. At the chime, the time will be %s. \x08 *DING*" (Mclock.elapsed_ns mclock) @@ str_of_time (current_time, tz));
+      Time.sleep_ns 1_000_000_000L >>= speak pclock mclock
     in
-    speak ()
+    speak pclock mclock ()
 end

--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -1,6 +1,6 @@
 open Mirage
 
-let main = foreign "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
+let main = foreign "Unikernel.Main" (console @-> network @-> mclock @-> time @-> job)
 
 let () =
   let libraries = [ "charrua-core.server"; "tcpip.ipv4";
@@ -8,5 +8,5 @@ let () =
                     "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"] in
   let packages = ["charrua-core"; "tcpip"] in
   register "dhcp" ~libraries ~packages [
-    main $ default_console $ tap0 $ default_clock $ default_time
+    main $ default_console $ tap0 $ default_monotonic_clock $ default_time
   ]

--- a/dns/config.ml
+++ b/dns/config.ml
@@ -11,9 +11,9 @@ let dns_handler =
   let packages = ["dns"; "mirage-logs"; "duration"] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (clock @-> kv_ro @-> stackv4 @-> job)
+    "Unikernel.Main" (kv_ro @-> stackv4 @-> job)
 
 let stack = generic_stackv4 tap0
 
 let () =
-  register "dns" [dns_handler $ default_clock $ data $ stack]
+  register "dns" [dns_handler $ data $ stack]

--- a/dns/unikernel.ml
+++ b/dns/unikernel.ml
@@ -14,8 +14,7 @@ let test_hostname = "dark.recoil.org"
 (* Server settings *)
 let listening_port = 53
 
-module Main (Clock:V1.CLOCK) (K:V1_LWT.KV_RO) (S:V1_LWT.STACKV4) = struct
-  module Logs_reporter = Mirage_logs.Make(Clock)
+module Main (K:V1_LWT.KV_RO) (S:V1_LWT.STACKV4) = struct
 
   module U = S.UDPV4
   module Resolver = Dns_resolver_mirage.Make(OS.Time)(S)
@@ -76,9 +75,8 @@ module Main (Clock:V1.CLOCK) (K:V1_LWT.KV_RO) (S:V1_LWT.STACKV4) = struct
     Server_log.info (fun f -> f "DNS server listening on UDP port %d" listening_port);
     S.listen s
 
-  let start () kv_store stack =
+  let start kv_store stack =
     Logs.(set_level (Some Info));
-    Logs_reporter.(create () |> run) @@ fun () ->
     load_zone kv_store >>= fun zonebuf ->
     Lwt.join [
       serve stack zonebuf;

--- a/ethifv4/config.ml
+++ b/ethifv4/config.ml
@@ -7,9 +7,9 @@ let main =
   let packages = ["tcpip"] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
+    "Unikernel.Main" (console @-> network @-> mclock @-> time @-> job)
 
 let () =
   register "ethifv4" [
-    main $ default_console $ tap0 $ default_clock $ default_time
+    main $ default_console $ tap0 $ default_monotonic_clock $ default_time
   ]

--- a/ping/config.ml
+++ b/ping/config.ml
@@ -5,7 +5,7 @@ let main =
   let libraries = [ "tcpip.arpv4"; "tcpip.ethif"; "tcpip.ipv4" ] in
   foreign
     ~libraries ~packages
-    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
+    "Unikernel.Main" (console @-> network @-> mclock @-> time @-> job)
 
 let () =
-  register "ping" [ main $ default_console $ tap0 $ default_clock $ default_time ]
+  register "ping" [ main $ default_console $ tap0 $ default_monotonic_clock $ default_time ]

--- a/ping/unikernel.ml
+++ b/ping/unikernel.ml
@@ -10,7 +10,7 @@ let ipaddr   = "10.0.0.2"
 let netmask  = "255.255.255.0"
 let gateways = ["10.0.0.1"]
 
-module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.CLOCK) (Time: V1_LWT.TIME) = struct
+module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.MCLOCK) (Time: V1_LWT.TIME) = struct
 
   module E = Ethif.Make(N)
   module A = Arpv4.Make(E)(Clock)(Time)
@@ -22,10 +22,10 @@ module Main (C:CONSOLE) (N:NETWORK) (Clock: V1.CLOCK) (Time: V1_LWT.TIME) = stru
     | `Error _e -> Lwt.fail (Failure ("Error starting " ^ name))
     | `Ok t     -> Lwt.return t
 
-  let start c n _clock _time =
+  let start c n clock _time =
     C.log c (green "starting...");
     or_error c "Ethif" E.connect n >>= fun e ->
-    or_error c "Arpv4" A.connect e >>= fun a ->
+    or_error c "Arpv4" (A.connect e) clock >>= fun a ->
     or_error c "Ipv4" (I.connect e) a >>= fun i ->
 
     I.set_ip i (Ipaddr.V4.of_string_exn ipaddr) >>= fun () ->

--- a/ping6/config.ml
+++ b/ping6/config.ml
@@ -5,7 +5,7 @@ let main =
   let libraries = [ "tcpip.ethif"; "tcpip.ipv6" ] in
   foreign
     ~packages ~libraries
-    "Unikernel.Main" (console @-> network @-> clock @-> time @-> job)
+    "Unikernel.Main" (console @-> network @-> mclock @-> time @-> job)
 
 let () =
-  register "ping" [ main $ default_console $ tap0 $ default_clock $ default_time ]
+  register "ping" [ main $ default_console $ tap0 $ default_monotonic_clock $ default_time ]

--- a/ping6/unikernel.ml
+++ b/ping6/unikernel.ml
@@ -9,7 +9,7 @@ let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
 let ipaddr   = "fc00::2"
 let gateways = ["fc00::1"]
 
-module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.CLOCK) (Time : TIME) = struct
+module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.MCLOCK) (Time : TIME) = struct
 
   module E = Ethif.Make(N)
   module I = Ipv6.Make(E)(Time)(Clock)
@@ -20,10 +20,10 @@ module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.CLOCK) (Time : TIME) = struct
     | `Error e -> fail (Failure ("Error starting " ^ name))
     | `Ok t -> return t
 
-  let start c n _clock _time =
+  let start c n clock _time =
     C.log c (green "starting...");
     or_error c "Ethif" E.connect n >>= fun e ->
-    or_error c "Ipv6"  I.connect e >>= fun i ->
+    or_error c "Ipv6"  (I.connect e) clock >>= fun i ->
 
     I.set_ip i (Ipaddr.V6.of_string_exn ipaddr) >>= fun () ->
     I.set_ip_gateways i (List.map Ipaddr.V6.of_string_exn gateways) >>= fun () ->

--- a/static_website/config.ml
+++ b/static_website/config.ml
@@ -14,7 +14,7 @@ let main =
   let keys = [ Key.abstract port ] in
   foreign
     ~libraries ~packages ~keys
-    "Dispatch.Main" (clock @-> kv_ro @-> http @-> job)
+    "Dispatch.Main" (kv_ro @-> http @-> job)
 
 let () =
-  register "www" [main $ default_clock $ data $ http_srv]
+  register "www" [main $ data $ http_srv]

--- a/static_website/dispatch.ml
+++ b/static_website/dispatch.ml
@@ -29,8 +29,6 @@ module Main (FS:V1_LWT.KV_RO) (S:Cohttp_lwt.Server) = struct
         ) (fun _exn -> S.respond_not_found ())
 
   let start fs http =
-    Logs.(set_level (Some Info));
-
     let callback (_, cid) request _body =
       let uri = Cohttp.Request.uri request in
       let cid = Cohttp.Connection.to_string cid in

--- a/static_website/dispatch.ml
+++ b/static_website/dispatch.ml
@@ -3,8 +3,7 @@ open Lwt.Infix
 let server_src = Logs.Src.create "server" ~doc:"HTTP server"
 module Server_log = (val Logs.src_log server_src : Logs.LOG)
 
-module Main (Clock:V1.CLOCK) (FS:V1_LWT.KV_RO) (S:Cohttp_lwt.Server) = struct
-  module Logs_reporter = Mirage_logs.Make(Clock)
+module Main (FS:V1_LWT.KV_RO) (S:Cohttp_lwt.Server) = struct
 
   let read_fs fs name =
     FS.size fs name >>= function
@@ -29,9 +28,8 @@ module Main (Clock:V1.CLOCK) (FS:V1_LWT.KV_RO) (S:Cohttp_lwt.Server) = struct
           S.respond_string ~status:`OK ~body ~headers ()
         ) (fun _exn -> S.respond_not_found ())
 
-  let start _clock fs http =
+  let start fs http =
     Logs.(set_level (Some Info));
-    Logs_reporter.(create () |> run) @@ fun () ->
 
     let callback (_, cid) request _body =
       let uri = Cohttp.Request.uri request in

--- a/static_website_tls/config.ml
+++ b/static_website_tls/config.ml
@@ -24,7 +24,7 @@ let main =
   let keys = List.map Key.abstract [ http_port; https_port ] in
   foreign
     ~libraries ~packages ~keys
-    "Dispatch.HTTPS" (clock @-> kv_ro @-> kv_ro @-> http @-> job)
+    "Dispatch.HTTPS" (pclock @-> kv_ro @-> kv_ro @-> http @-> job)
 
 let () =
-  register "https" [main $ default_clock $ data $ certs $ https_srv]
+  register "https" [main $ default_posix_clock $ data $ certs $ https_srv]


### PR DESCRIPTION
Use PCLOCK and MCLOCK instead of CLOCK.  Also, include a `clock` example which illustrates the difference between these two module types.