### PR TITLE
Fixes to build against Solo5 targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ mir-*
 make-fat*-image.sh
 *_gen.ml
 *_gen.ml.in
+**/_build-ukvm/
+**/Makefile.ukvm
+**/ukvm-bin

--- a/conduit_server/config.ml
+++ b/conduit_server/config.ml
@@ -15,9 +15,9 @@ let direct =
 (* Only add the Unix socket backend if the configuration mode is Unix *)
 let socket =
   let c = default_console in
-  if_impl Key.is_xen
-    noop
+  if_impl Key.is_unix
     (handler $ c $ conduit_direct (socket_stackv4 [Ipaddr.V4.any]))
+    noop
 
 let () =
   register "conduit_server" [direct ; socket ]

--- a/conduit_server_manual/config.ml
+++ b/conduit_server_manual/config.ml
@@ -15,9 +15,9 @@ let direct =
 (* Only add the Unix socket backend if the configuration mode is Unix *)
 let socket =
   let c = default_console in
-  if_impl Key.is_xen
-    noop
+  if_impl Key.is_unix
     (handler $ default_time $ c $ socket_stackv4 [Ipaddr.V4.any])
+    noop
 
 let () =
   register "conduit_server" [direct ; socket]

--- a/io_page/config.ml
+++ b/io_page/config.ml
@@ -2,7 +2,7 @@ open Mirage
 
 let main =
   foreign
-    ~libraries:["duration"] ~packages:["duration"]
+    ~libraries:["duration"; "io-page"] ~packages:["duration"; "io-page"]
     "Unikernel.Main" (time @-> console @-> job)
 
 let () = register "io_page" [


### PR DESCRIPTION
These changes fix the build with `MODE=ukvm` and `MODE=virtio`.

@yomimono Could you please check I'm doing the right thing in 9073886 and not papering over a dependency problem in the `mirage` frontend for the Solo5 targets. (See also #177)