### PR TITLE
Travis: Add Solo5 (ukvm, virtio) targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ env:
   matrix:
     - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
     - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
+    - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"
     - OCAML_VERSION=4.02 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
     - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
+    - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ env:
     - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
     - TESTS=false
     - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing mirage-profile:https://github.com/mirage/mirage-profile.git"
-    - WITH_TRACING=1
   matrix:
-    - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.03 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
+    - OCAML_VERSION=4.03 WITH_TRACING=1 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
     - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
     - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"
-    - OCAML_VERSION=4.02 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.02 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
+    - OCAML_VERSION=4.02 WITH_TRACING=1 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
     - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
     - OCAML_VERSION=4.02 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"


### PR DESCRIPTION
With #181 and dependencies in place, we can now build mirage-skeleton for the Solo5 targets (ukvm, virtio).

Note that I've added these for both the 4.02 and 4.03 compilers, perhaps that is overkill in terms of needlessly slowing down the build?
