### PR TITLE
use Astring instead of Str in dhcp example

### DIFF
--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -5,8 +5,8 @@ let main = foreign "Unikernel.Main" (console @-> network @-> mclock @-> time @->
 let () =
   let libraries = [ "charrua-core.server"; "tcpip.ipv4";
                     "charrua-core.wire"; "tcpip.udp";
-                    "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "astring"] in
-  let packages = ["charrua-core"; "tcpip";"astring"] in
+                    "tcpip"; "tcpip.ethif"; "tcpip.arpv4"] in
+  let packages = ["charrua-core"; "tcpip"] in
   register "dhcp" ~libraries ~packages [
     main $ default_console $ tap0 $ default_monotonic_clock $ default_time
   ]

--- a/dhcp/config.ml
+++ b/dhcp/config.ml
@@ -5,8 +5,8 @@ let main = foreign "Unikernel.Main" (console @-> network @-> mclock @-> time @->
 let () =
   let libraries = [ "charrua-core.server"; "tcpip.ipv4";
                     "charrua-core.wire"; "tcpip.udp";
-                    "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "str"] in
-  let packages = ["charrua-core"; "tcpip"] in
+                    "tcpip"; "tcpip.ethif"; "tcpip.arpv4"; "astring"] in
+  let packages = ["charrua-core"; "tcpip";"astring"] in
   register "dhcp" ~libraries ~packages [
     main $ default_console $ tap0 $ default_monotonic_clock $ default_time
   ]

--- a/dhcp/unikernel.ml
+++ b/dhcp/unikernel.ml
@@ -6,17 +6,13 @@ let green fmt  = Printf.sprintf ("\027[32m"^^fmt^^"\027[m")
 let yellow fmt = Printf.sprintf ("\027[33m"^^fmt^^"\027[m")
 let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
 
-let string_of_stream s =
-  let s = List.map Cstruct.to_string s in
-  (String.concat "" s)
-
 module Main (C: CONSOLE) (N: NETWORK) (MClock : V1.MCLOCK) (Time: TIME) = struct
   module E = Ethif.Make(N)
   module A = Arpv4.Make(E)(MClock)(Time)
   module DC = Dhcp_config
 
   let log c s =
-    Str.split_delim (Str.regexp "\n") s |>
+    Astring.String.cuts ~sep:"\n" s |>
     List.iter (fun line -> C.log c line)
 
   let of_interest dest net =


### PR DESCRIPTION
I'm actually not particularly convinced that we really need to split on `\n` here... any opinion @yomimono @haesbaert 

The reason to get rid of `Str` is that there are better options in OCaml for regular expressions, and it also adds C code to our OCaml runtime...

please let me know what you think