### PR TITLE
Use create_ipv6 in ping6 example

### DIFF
--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -9,7 +9,7 @@ clean: $(patsubst %,%-clean,$(TARGETS))
 %-build:
 	TARGET=$* $(MIRAGE) configure -f src/config.ml -t $(MODE) $(MIRAGE_FLAGS)
 	$(MAKE) -C src depend
-	TARGET=$* $(MIRAGE) build -f src/config.ml -t $(MODE) $(MIRAGE_FLAGS)
+	TARGET=$* $(MIRAGE) build -f src/config.ml $(MIRAGE_FLAGS)
 
 %-clean:
 	TARGET=$* $(MIRAGE) clean -f src/config.ml

--- a/ping6/config.ml
+++ b/ping6/config.ml
@@ -1,10 +1,17 @@
 open Mirage
 
 let main =
-  let packages = [ package ~sublibs:["ethif"; "ipv6"] "tcpip" ] in
   foreign
-    ~packages
-    "Unikernel.Main" (console @-> network @-> mclock @-> time @-> job)
+    "Unikernel.Main" (console @-> network @-> ethernet @-> ipv6 @-> job)
+let net = default_network
+let ethif = etif net
+let ipv6 =
+  let config = {
+    addresses = [];
+    netmasks  = [];
+    gateways  = [];
+  } in
+  create_ipv6 ethif config
 
 let () =
-  register "ping" [ main $ default_console $ default_network $ default_monotonic_clock $ default_time ]
+  register "ping" [ main $ default_console $ default_network $ ethif $ ipv6 ]

--- a/ping6/unikernel.ml
+++ b/ping6/unikernel.ml
@@ -6,22 +6,9 @@ let green fmt  = Printf.sprintf ("\027[32m"^^fmt^^"\027[m")
 let yellow fmt = Printf.sprintf ("\027[33m"^^fmt^^"\027[m")
 let blue fmt   = Printf.sprintf ("\027[36m"^^fmt^^"\027[m")
 
-let ipaddr   = "fc00::2"
-let gateways = ["fc00::1"]
+module Main (C:CONSOLE) (N: NETWORK) (E: ETHIF) (I:IPV6) = struct
 
-module Main (C:CONSOLE) (N:NETWORK) (Clock : V1.MCLOCK) (Time : TIME) = struct
-
-  module E = Ethif.Make(N)
-  module I = Ipv6.Make(E)(Time)(Clock)
-
-  let start c n clock _time =
-    let gateways = (List.map Ipaddr.V6.of_string_exn gateways) in
-    C.log c (green "starting...") >>= fun () ->
-    E.connect n >>= fun e ->
-    I.connect ~ip:(Ipaddr.V6.of_string_exn ipaddr)
-              ~gateways
-              e clock >>= fun i ->
-
+  let start c n e i =
     let handler s = fun ~src ~dst data ->
       C.log c (yellow "%s > %s %s" (Ipaddr.V6.to_string src) (Ipaddr.V6.to_string dst) s)
     in


### PR DESCRIPTION
This way, `mirage configure --help` shows the keys for configuring ipv6.