### PR TITLE
don't repeat command line flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include Makefile.config
 
-TESTS = console network stackv4 ethifv4 io_page lwt static_website dns \
+TESTS = console network stackv4 ethifv4 io_page static_website dns \
         conduit_server static_website_tls http-fetch \
         dhcp hello block kv_ro_crunch kv_ro netif-forward ping6
 
@@ -16,9 +16,9 @@ CLEANS  = $(patsubst %, %-clean,     $(TESTS))
 all: build
 
 configure: $(CONFIGS)
-build: $(BUILDS) lwt-build
+build: $(BUILDS)
 testrun: $(TESTRUN)
-clean: $(CLEANS) lwt-clean
+clean: $(CLEANS)
 
 ## lwt special cased
 lwt: lwt-clean lwt-build
@@ -36,7 +36,7 @@ lwt-testrun:
 
 ## default tests
 %-configure:
-	$(MIRAGE) configure -f $*/config.ml -t $(MODE) $(MIRAGE_FLAGS)
+	cd $* && $(MIRAGE) configure -t $(MODE) $(MIRAGE_FLAGS)
 
 %-build: %-configure
 	cd $* && $(MAKE) depend && $(MAKE)

--- a/lwt/Makefile
+++ b/lwt/Makefile
@@ -7,10 +7,9 @@ build: $(patsubst %,%-build,$(TARGETS))
 clean: $(patsubst %,%-clean,$(TARGETS))
 
 %-build:
-	TARGET=$* $(MIRAGE) configure -f src/config.ml -t $(MODE) $(MIRAGE_FLAGS)
-	$(MAKE) -C src depend
-	TARGET=$* $(MIRAGE) build -f src/config.ml $(MIRAGE_FLAGS)
+	cd src && TARGET=$* $(MIRAGE) configure -t $(MODE) $(MIRAGE_FLAGS)
+	cd src && $(MAKE) depend && $(MAKE) build
 
 %-clean:
-	TARGET=$* $(MIRAGE) clean -f src/config.ml
+	cd src && $(MAKE) clean
 	$(RM) log


### PR DESCRIPTION
let's see what travis says... tracing example is still likely broken with

```
File "unikernel.ml", line 15, characters 6-17:
Error: This pattern matches values of type [< `Error of 'a | `Ok of 'b ]
       but a pattern was expected which matches values of type
         (S.TCPV4.flow, S.TCPV4.error) Result.result =
           (S.TCPV4.flow, S.TCPV4.error) result
```