### PR TITLE
RFC: move more logic in mirage-skeleton to libraries?

### DIFF
--- a/static_website/dispatch.ml
+++ b/static_website/dispatch.ml
@@ -1,48 +1,8 @@
-open Lwt.Infix
-
-let server_src = Logs.Src.create "server" ~doc:"HTTP server"
 module Server_log = (val Logs.src_log server_src : Logs.LOG)
 
 module Main (FS:Mirage_types_lwt.KV_RO) (S:Cohttp_lwt.Server) = struct
 
-  let failf fmt = Fmt.kstrf Lwt.fail_with fmt
-
-  let read_fs fs name =
-    FS.size fs name >>= function
-    | Error e -> failf "read: %a" FS.pp_error e
-    | Ok size ->
-      FS.read fs name 0L size >>= function
-      | Error e -> failf "read %a" FS.pp_error e
-      | Ok bufs -> Lwt.return (Cstruct.copyv bufs)
-
-  let rec dispatcher fs uri =
-    match Uri.path uri with
-    | ("" | "/") as path ->
-      Server_log.info (fun f -> f "request for '%s'" path);
-      dispatcher fs (Uri.with_path uri "index.html")
-    | path ->
-      Server_log.info (fun f -> f "request for '%s'" path);
-      Lwt.catch (fun () ->
-          read_fs fs path >>= fun body ->
-          let mime_type = Magic_mime.lookup path in
-          let headers = Cohttp.Header.init () in
-          let headers = Cohttp.Header.add headers "content-type" mime_type in
-          S.respond_string ~status:`OK ~body ~headers ()
-        ) (fun _exn -> S.respond_not_found ())
-
   let start fs http =
-    let callback (_, cid) request _body =
-      let uri = Cohttp.Request.uri request in
-      let cid = Cohttp.Connection.to_string cid in
-      Server_log.info (fun f -> f "[%s] serving %s" cid (Uri.to_string uri));
-      dispatcher fs uri
-    in
-    let conn_closed (_, cid) =
-      let cid = Cohttp.Connection.to_string cid in
-      Server_log.info (fun f -> f "[%s] closing" cid);
-    in
-    let port = Key_gen.port () in
-    Server_log.info (fun f -> f "listening on %d/TCP" port);
-    http (`TCP port) (S.make ~conn_closed ~callback ())
+    Shim.start (module Server_log) (module FS) (module S) fs http
 
 end

--- a/static_website/dispatch.ml
+++ b/static_website/dispatch.ml
@@ -1,3 +1,4 @@
+let server_src = Logs.Src.create "server" ~doc:"HTTP server"
 module Server_log = (val Logs.src_log server_src : Logs.LOG)
 
 module Main (FS:Mirage_types_lwt.KV_RO) (S:Cohttp_lwt.Server) = struct

--- a/static_website/shim.ml
+++ b/static_website/shim.ml
@@ -1,0 +1,67 @@
+open Lwt.Infix
+open Astring
+
+let failf fmt = Fmt.kstrf Lwt.fail_with fmt
+
+let read_fs (type s) (module M:Mirage_kv_lwt.RO with type t=s) t name =
+  M.size t name >>= function
+  | Error e -> failf "read: %a" M.pp_error e
+  | Ok size ->
+      M.read t name 0L size >>= function
+      | Error e -> failf "read %a" M.pp_error e
+      | Ok bufs -> Lwt.return (Cstruct.copyv bufs)
+
+let exists (type s) (module M:Mirage_kv_lwt.RO with type t=s) t name =
+  M.mem t name >>= function
+  | Ok true -> Lwt.return_true
+  | _ -> Lwt.return_false
+
+let respond m t (module S:Cohttp_lwt.Server) path =
+  read_fs m t path >>= fun body ->
+  let mime_type = Magic_mime.lookup path in
+  let headers = Cohttp.Header.init_with "content-type" mime_type in
+  S.respond_string ~status:`OK ~body ~headers ()
+
+let dispatcher
+  (type s) (module M:Mirage_kv_lwt.RO with type t=s) 
+  (module L:Logs.LOG) (module S:Cohttp_lwt.Server) =
+  let rec fn fs uri =
+    match Uri.path uri with
+    | ("" | "/") as path ->
+      L.info (fun f -> f "request for '%s'" path);
+      fn fs (Uri.with_path uri "index.html")
+    | path when String.is_suffix ~affix:"/" path ->
+      L.info (fun f -> f "request for '%s'" path);
+      fn fs (Uri.with_path uri "index.html")
+    | path ->
+      L.info (fun f -> f "request for '%s'" path);
+      Lwt.catch (fun () -> 
+        read_fs (module M) fs path >>= fun body ->
+        let mime_type = Magic_mime.lookup path in
+        let headers = Cohttp.Header.init_with "content-type" mime_type in
+        S.respond_string ~status:`OK ~body ~headers ()
+      ) (fun _exn ->
+         let with_index = Fmt.strf "%s/index.html" path in
+         exists (module M) fs with_index >>= function
+         | true -> fn fs (Uri.with_path uri with_index)
+         | false ->  S.respond_not_found ()
+      )
+  in fn
+
+let start (module L:Logs.LOG) 
+    (type f) (module M:Mirage_kv_lwt.RO with type t=f)
+    (type s) (module S:Cohttp_lwt.Server with type t=s) fs http =
+
+    let callback (_, cid) request _body =
+      let uri = Cohttp.Request.uri request in
+      let cid = Cohttp.Connection.to_string cid in
+      L.info (fun f -> f "[%s] serving %s" cid (Uri.to_string uri));
+      dispatcher (module M) (module L) (module S) fs uri
+    in
+    let conn_closed (_, cid) =
+      let cid = Cohttp.Connection.to_string cid in
+      L.info (fun f -> f "[%s] closing" cid);
+    in
+    let port = Key_gen.port () in
+    L.info (fun f -> f "listening on %d/TCP" port);
+    http (`TCP port) (S.make ~conn_closed ~callback ())


### PR DESCRIPTION
In this PR, the Shim.ml could live in mirage-http, and so users wanting a static website require very little boilerplate.  Should I move this into mirage-http and continue to develop the static serving features?