### PR TITLE
device-usage/prng: print some random numbers, and the supported entropy sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ env:
     - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
     - TESTS=false
     - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - UPDATE_GCC_BINUTILS=1
   matrix:
     - OCAML_VERSION=4.03 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.03 WITH_TRACING=1 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
-    - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
-    - OCAML_VERSION=4.03 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"
+    - OCAML_VERSION=4.03 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
+    - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=virtio && make clean"
     - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.04 WITH_TRACING=1 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
-    - OCAML_VERSION=4.04 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=ukvm  && make clean"
-    - OCAML_VERSION=4.04 UPDATE_GCC_BINUTILS=1 POST_INSTALL_HOOK="make MODE=virtio  && make clean"
+    - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
+    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=virtio && make clean"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ TESTS = \
   device-usage/kv_ro \
   device-usage/network \
   device-usage/ping6 \
+  device-usage/prng \
   applications/dhcp \
   applications/dns \
   applications/static_website_tls

--- a/device-usage/prng/config.ml
+++ b/device-usage/prng/config.ml
@@ -1,0 +1,11 @@
+open Mirage
+
+let main = foreign ~deps:[abstract nocrypto] "Unikernel.Main" (random @-> job)
+
+let () =
+  let packages = [
+    package "randomconv" ;
+    package "mirage-entropy" ;
+    package ~sublibs:["mirage"] "nocrypto"
+  ] in
+  register ~packages "prng" [main $ default_random]

--- a/device-usage/prng/config.ml
+++ b/device-usage/prng/config.ml
@@ -6,6 +6,9 @@ let () =
   let packages = [
     package "randomconv" ;
     package "mirage-entropy" ;
+    (* access to entropy sources is only via Nocrypto_entropy_mirage.sources,
+       which is only compiled when nocrypto uses xen or freestanding flags *)
+    package ~ocamlfind:[] "ocaml-freestanding" ;
     package ~sublibs:["mirage"] "nocrypto"
   ] in
   register ~packages "prng" [main $ default_random]

--- a/device-usage/prng/unikernel.ml
+++ b/device-usage/prng/unikernel.ml
@@ -1,0 +1,54 @@
+module Main (R : Mirage_types_lwt.RANDOM) = struct
+
+  let s_to_str (s : Entropy.source) = match s with
+    | `Timer -> "timer (rdtsc)"
+    | `Rdseed -> "rdseed"
+    | `Rdrand -> "rdrand"
+    | `Xentropyd -> "xentropyd"
+
+  let p_to_str = function
+    | `Stdlib -> "stdlib"
+    | `Nocrypto -> "Fortuna"
+
+  let other = function
+    | `Stdlib -> `Nocrypto
+    | `Nocrypto -> `Stdlib
+
+  let howto = function
+    | `Stdlib -> "stdlib"
+    | `Nocrypto -> "nocrypto"
+
+  let t_to_str = function
+    | `Unix  -> "unix"
+    | `Xen -> "xen"
+    | `Qubes -> "qubes"
+    | `MacOSX -> "macosx"
+    | `Virtio -> "virtio"
+    | `Ukvm -> "ukvm"
+
+  let start _ _r =
+    let rng = Key_gen.prng () in
+    let t = Key_gen.target () in
+    let sources = match Nocrypto_entropy_mirage.sources () with
+      | None -> "not initialised"
+      | Some xs -> String.concat "; " (List.map s_to_str xs)
+    in
+    Logs.info (fun m -> m "PRNG example running on %s" Sys.os_type) ;
+    Logs.info (fun m -> m "using %s PRNG" (p_to_str rng)) ;
+    if rng = `Nocrypto then
+      if t = `Unix || t = `MacOSX then
+        Logs.info (fun m -> m "/dev/[u]random is used for entropy harvesting")
+      else
+        Logs.info (fun m -> m "Fortuna entropy sources: %s" sources) ;
+    Logs.info (fun m -> m "32 byte random:@ %a" Cstruct.hexdump_pp (R.generate 32)) ;
+    let open Randomconv in
+    Logs.info (fun m -> m "Random numbers: 0x%02X 0x%04X 0x%08lX 0x%016LX"
+                  (int8 R.generate) (int16 R.generate)
+                  (int32 R.generate) (int64 R.generate)) ;
+    let other = other rng in
+    Logs.info (fun m -> m "(use %s PRNG by executing 'mirage configure --prng %s -t %s')"
+                  (p_to_str other) (howto other) (t_to_str t)) ;
+    Lwt.return_unit
+
+
+end


### PR DESCRIPTION
this is a small example using the provided random number generators ;)

for unix, the `package ~subllibs:["mirage"] "nocrypto"` is needed, since nocrypto.mirage is only in a xen/freestanding world dragged in as dependency.  unix uses nocrypto.lwt (and the rng initialisation over there).