### PR TITLE
Fix dhcp application.

### DIFF
--- a/applications/dhcp/unikernel.ml
+++ b/applications/dhcp/unikernel.ml
@@ -25,7 +25,8 @@ module Main (C: CONSOLE) (N: NETWORK) (MClock : Mirage_types.MCLOCK) (Time: TIME
       Lwt.return leases
     | Ok pkt ->
       let open Dhcp_server.Input in
-      match input_pkt config leases pkt (MClock.elapsed_ns clock |> Int64.to_float) with
+      let now = MClock.elapsed_ns clock |> Duration.to_sec |> float_of_int in
+      match input_pkt config leases pkt now with
       | Silence -> Lwt.return leases
       | Update leases ->
         log console (blue "Received packet %s - updated lease database" (Dhcp_wire.pkt_to_string pkt)) >>= fun () ->


### PR DESCRIPTION
This was broken on the Clock -> MClock conversion.
Good news is that the library doesn't behave so badly, it was emiting
Leases with duration=0.

Next version of charrua-core should take an Int64 as the argument for time.

18166efdf6b434ecb22bec23a322fa30e57975f2