### PR TITLE
charrua-core expects int32 time now, not float

### DIFF
--- a/applications/dhcp/config.ml
+++ b/applications/dhcp/config.ml
@@ -4,7 +4,7 @@ let main = foreign "Unikernel.Main" (console @-> network @-> mclock @-> time @->
 
 let () =
   let packages = [
-    package ~sublibs:["server"; "wire"] "charrua-core";
+    package ~min:"0.5" ~sublibs:["server"; "wire"] "charrua-core";
     package ~sublibs:["ethif"; "arpv4"] "tcpip"
   ]
   in

--- a/applications/dhcp/unikernel.ml
+++ b/applications/dhcp/unikernel.ml
@@ -25,7 +25,7 @@ module Main (C: CONSOLE) (N: NETWORK) (MClock : Mirage_types.MCLOCK) (Time: TIME
       Lwt.return leases
     | Ok pkt ->
       let open Dhcp_server.Input in
-      let now = MClock.elapsed_ns clock |> Duration.to_sec |> float_of_int in
+      let now = MClock.elapsed_ns clock |> Duration.to_sec |> Int32.of_int in
       match input_pkt config leases pkt now with
       | Silence -> Lwt.return leases
       | Update leases ->


### PR DESCRIPTION
Will fix tests, once charrua-core 0.5 is released.