### PR TITLE
adjust example for (now released) dns.0.20.0, which does not contain …

### DIFF
--- a/applications/dns/config.ml
+++ b/applications/dns/config.ml
@@ -7,7 +7,7 @@ let data = crunch "./data"
     package, and it requires a logging console, a read-only
     key/value store and a TCP/IP stack. *)
 let dns_handler =
-  let packages = [package ~sublibs:["mirage"] "dns"; package "duration"] in
+  let packages = [package ~min:"0.20.0" ~sublibs:["mirage"] "dns"; package "duration"] in
   foreign
     ~packages
     "Unikernel.Main" (kv_ro @-> stackv4 @-> job)


### PR DESCRIPTION
…a custom Buf module anymore