### PR TITLE
Build fix: nocrypto moved to mirage-solo5; unsupported Xen on 4.03 dropped from CI matrix; application/dns package updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - UPDATE_GCC_BINUTILS=1
   matrix:
     - OCAML_VERSION=4.03 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.03 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
     - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
     - OCAML_VERSION=4.03 POST_INSTALL_HOOK="make MODE=virtio && make clean"
     - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"

--- a/applications/dns/config.ml
+++ b/applications/dns/config.ml
@@ -7,7 +7,7 @@ let data = crunch "./data"
     package, and it requires a logging console, a read-only
     key/value store and a TCP/IP stack. *)
 let dns_handler =
-  let packages = [package ~min:"0.20.0" ~sublibs:["mirage"] "dns"; package "duration"] in
+  let packages = [package ~min:"1.0.0" "dns"; package "mirage-dns"; package "duration"] in
   foreign
     ~packages
     "Unikernel.Main" (kv_ro @-> stackv4 @-> job)

--- a/device-usage/prng/config.ml
+++ b/device-usage/prng/config.ml
@@ -8,7 +8,7 @@ let () =
     package "mirage-entropy" ;
     (* access to entropy sources is only via Nocrypto_entropy_mirage.sources,
        which is only compiled when nocrypto uses xen or freestanding flags *)
-    package ~ocamlfind:[] "ocaml-freestanding" ;
+    package ~ocamlfind:[] "mirage-solo5" ;
     package ~sublibs:["mirage"] "nocrypto"
   ] in
   register ~packages "prng" [main $ default_random]


### PR DESCRIPTION
@hannesm this is the smallest-possible try to fix the build.

### "ocamlfind: Package `nocrypto.mirage' not found”

This was about a moved package, `nocrypto`. It moved from `ocaml-freestanding` to `mirage-solo5`.

Our [config.ml for that](https://github.com/mirage/mirage-skeleton/blame/cc3f78e36e77b188b821b5fde3f876b762df7297/device-usage/prng/config.ml#L11)

A [PR elsewhere that does the same change](https://github.com/ocaml/opam-repository/pull/9416/files)

### xen on 4.03 removed from CI matrix

This OCaml version is not supported, right now.

### application/dns package updates