### PR TITLE
README: Use 3.0.5 in version instruction wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ proceeding:
 
 ```
     $ mirage --version
-    3.0.0
+    3.0.5
 ```
 
 


### PR DESCRIPTION
This PR changes the example output version number to `3.0.5`.

(Currently, the example output version number is the _same_ as the "at least 3.0.0", in the previous sentence.)