### PR TITLE
separate keys for the two filesystems in static_website_tls

### DIFF
--- a/applications/static_website_tls/config.ml
+++ b/applications/static_website_tls/config.ml
@@ -1,7 +1,8 @@
 open Mirage
 
 let stack = generic_stackv4 default_network
-let data = generic_kv_ro "htdocs"
+let data_key = Key.(value @@ kv_ro ~group:"data" ())
+let data = generic_kv_ro ~key:data_key "htdocs"
 (* set ~tls to false to get a plain-http server *)
 let https_srv = http_server @@ conduit_direct ~tls:true stack
 
@@ -9,8 +10,10 @@ let http_port =
   let doc = Key.Arg.info ~doc:"Listening HTTP port." ["http"] in
   Key.(create "http_port" Arg.(opt int 8080 doc))
 
-(* some defaults are included here, but you can replace them with your own. *)
-let certs = generic_kv_ro "tls"
+let certs_key = Key.(value @@ kv_ro ~group:"certs" ())
+(* some default CAs and self-signed certificates are included in
+   the tls/ directory, but you can replace them with your own. *)
+let certs = generic_kv_ro ~key:certs_key "tls"
 
 let https_port =
   let doc = Key.Arg.info ~doc:"Listening HTTPS port." ["https"] in


### PR DESCRIPTION
Previously, attempting to specify `--kv_ro` for the `static_website_tls` example would result in strange behavior:

```
$ mirage configure -t xen --kv_ro=fat
Fatal error: exception (Invalid_argument "duplicate key: kv_ro")
```

Now, the datastores can both be configured separately:

```
$ mirage configure -t xen --certs-kv_ro=crunch --data-kv_ro=fat
$
```