### PR TITLE
get ready for mirage 3.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 env:
   global:
     - TESTS=false
-    - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing mirage"
     - UPDATE_GCC_BINUTILS=1
   matrix:
     - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ env:
     - PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing mirage"
     - UPDATE_GCC_BINUTILS=1
   matrix:
-    - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
-    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
-    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=virtio && make clean"
+    - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=muen && make clean"
     - OCAML_VERSION=4.05 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
     - OCAML_VERSION=4.05 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=virtio && make clean"
+    - OCAML_VERSION=4.06 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
+    - OCAML_VERSION=4.05 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean"
+    - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
+    - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=virtio && make clean"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include Makefile.config
 
-TESTS = \
+BASE_TESTS = \
   tutorial/noop \
   tutorial/noop-functor \
   tutorial/hello \
@@ -10,7 +10,6 @@ TESTS = \
   tutorial/lwt/heads2 \
   tutorial/lwt/timeout1 \
   tutorial/lwt/timeout2 \
-  device-usage/block \
   device-usage/clock \
   device-usage/conduit_server \
   device-usage/console \
@@ -21,6 +20,13 @@ TESTS = \
   applications/dhcp \
   applications/dns \
   applications/static_website_tls
+
+ifeq ($(MODE),muen)
+	TESTS = $(BASE_TESTS)
+else
+	TESTS = $(BASE_TESTS)
+	TESTS += device-usage/block
+endif
 
 ifdef WITH_TRACING
 TESTS += device-usage/tracing

--- a/device-usage/prng/unikernel.ml
+++ b/device-usage/prng/unikernel.ml
@@ -21,6 +21,7 @@ module Main (R : Mirage_types_lwt.RANDOM) = struct
   let t_to_str = function
     | `Unix  -> "unix"
     | `Xen -> "xen"
+    | `Muen -> "muen"
     | `Qubes -> "qubes"
     | `MacOSX -> "macosx"
     | `Virtio -> "virtio"


### PR DESCRIPTION
Include a test for the `muen` backend, make a few changes so it can pass.  Pin `mirage` since this is not yet released.