### PR TITLE
Updates for Solo5 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ myocamlbuild.ml
 *.xl.in
 *.xe
 *_libvirt.xml
+*.virtio
+*.hvt
+*.muen
 static*.ml
 static*.mli
 main.ml
@@ -29,8 +32,9 @@ mir-*
 make-fat*-image.sh
 *_gen.ml
 *_gen.ml.in
-**/Makefile.ukvm
-**/ukvm-bin
+**/Makefile.solo5-hvt
+**/solo5-hvt
+**/_build-solo5-hvt
 **/.mirage.config
 
 block/block_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ env:
     - UPDATE_GCC_BINUTILS=1
   matrix:
     - OCAML_VERSION=4.06 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
-    - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
+    - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=hvt && make clean"
     - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=virtio && make clean"
     - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=muen && make clean"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.05 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
-    - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=ukvm   && make clean"
+    - OCAML_VERSION=4.05 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=hvt && make clean"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=muen && make clean"
-    - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen  && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
-    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=virtio   && make clean"
+    - OCAML_VERSION=4.04 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
+    - OCAML_VERSION=4.04 POST_INSTALL_HOOK="make MODE=virtio && make clean"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ directly.
 #### To configure a unikernel before building:
 
 ```
-    $ mirage configure -t [ukvm|kvm|qubes|macosx|unix|xen]
+    $ mirage configure -t [hvt|virtio|qubes|macosx|unix|xen]
 ```
 
 The boot target is selected via the `-t` flag. The default target is `unix`.
@@ -167,10 +167,10 @@ Ukvm:
 
 ```
     $ cd hello
-    $ mirage configure -t ukvm
+    $ mirage configure -t hvt
     $ make depend
     $ make
-    $ ./ukvm-bin hello.ukvm
+    $ ./solo5-hvt hello.hvt
 ```
 
 Virtio:
@@ -180,7 +180,7 @@ Virtio:
     $ mirage configure -t virtio
     $ make depend
     $ make
-    $ solo5-run-virtio ./https.virtio
+    $ solo5-virtio-run ./https.virtio
 ```
 
 Macosx:

--- a/device-usage/prng/unikernel.ml
+++ b/device-usage/prng/unikernel.ml
@@ -25,7 +25,7 @@ module Main (R : Mirage_types_lwt.RANDOM) = struct
     | `Qubes -> "qubes"
     | `MacOSX -> "macosx"
     | `Virtio -> "virtio"
-    | `Ukvm -> "ukvm"
+    | `Hvt -> "hvt"
 
   let start _ _r =
     let rng = Key_gen.prng () in


### PR DESCRIPTION
As of Solo5 0.4.0, the "ukvm" target has been renamed to "hvt". Update mirage-skeleton to match. Along the way fix some nits in the documentation, and ignore more generated outputs.

CI is not expected to pass here; this needs to be merged concurrently with mirage/mirage#924.

/cc mirage/mirage#923.