### PR TITLE
xen with tracing fails on travis:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ env:
     - OCAML_VERSION=4.07 POST_INSTALL_HOOK="make MODE=muen && make clean"
     - OCAML_VERSION=4.06 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
     - OCAML_VERSION=4.06 POST_INSTALL_HOOK="make MODE=unix && make testrun SUDO=sudo && make clean"
-    - OCAML_VERSION=4.06 WITH_TRACING=1 POST_INSTALL_HOOK="make MODE=xen && make clean" PINS="lwt.dev:https://github.com/mirage/lwt.git#tracing"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=hvt && make clean"
     - OCAML_VERSION=4.05 POST_INSTALL_HOOK="make MODE=qubes && make clean"


### PR DESCRIPTION
I would not know how to fix this... once fixed in opam-repository, we can re-enable the travis job

```
File "main.ml", line 140, characters 31-41:
Error: Unbound module Gnt
Command exited with code 2.
run ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-tags'
     'predicate(mirage_xen),warn(A-4-41-42-44),debug,bin_annot,strict_sequence,principal,safe_string,color(always)'
     '-pkgs'
     'arp-mirage,ethernet,functoria-runtime,lwt,mirage-bootvar-xen,mirage-clock-freestanding,mirage-logs,mirage-net-xen,mirage-profile,mirage-profile-xen,mirage-random-stdlib,mirage-runtime,mirage-types,mirage-types-lwt,mirage-xen,tcpip,tcpip.icmpv4,tcpip.ipv4,tcpip.stack-direct,tcpip.tcp,tcpip.udp,tcpip.xen'
     '-cflags' '-g' '-lflags'
     '-g,-dontlink,unix,-dontlink,str,-dontlink,num,-dontlink,threads'
     '-tag-line' '<static*.*>: warn(-32-34)' '-Xs'
     '_build-solo5-hvt,_build-ukvm' 'main.native.o']: exited with 10
make[1]: *** [build] Error 1
make[1]: Leaving directory `/home/travis/build/mirage/mirage-skeleton/device-usage/tracing'
make: *** [device-usage/tracing-build] Error 2
'unset TESTS; OPAMYES=1 export OPAMYES; set -uex; make MODE=xen && make clean' exited 2. Terminating with 2
```