### PR TITLE
cohttp got released, no need for a custom overlay anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: false
 env:
   global:
     - TESTS=false
-    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#easy"
   matrix:
     - DISTRO=alpine OCAML_VERSION=4.09 POST_INSTALL_HOOK="make MODE=spt && make clean"
     - DISTRO=alpine OCAML_VERSION=4.08 POST_INSTALL_HOOK="make MODE=hvt && make clean"


### PR DESCRIPTION
the unix testrun will still fail since they assume some tap devices being around which are not (device-usage/ping6 ; device-usage/network)