### PR TITLE
Update to not use the Type constructor directly

### DIFF
--- a/device-usage/block/config.ml
+++ b/device-usage/block/config.ml
@@ -1,7 +1,7 @@
 open Mirage
 
 type shellconfig = ShellConfig
-let shellconfig = Type ShellConfig
+let shellconfig = Type.v ShellConfig
 
 let config_shell =
   let build _ =


### PR DESCRIPTION
Following https://github.com/mirage/mirage/pull/1053