### PR TITLE
add small example for postgres (using pgx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BASE_TESTS = \
   device-usage/kv_ro \
   device-usage/network \
   device-usage/ping6 \
+	device-usage/pgx \
   device-usage/prng \
   applications/dhcp \
   applications/static_website_tls

--- a/device-usage/pgx/config.ml
+++ b/device-usage/pgx/config.ml
@@ -1,0 +1,58 @@
+open Mirage
+
+let packages =
+  [ package "pgx"
+  ; package "pgx_lwt"
+  ; package "pgx_lwt_mirage"
+  ; package "logs"
+  ; package "mirage-logs"
+  ]
+;;
+
+let stack = generic_stackv4 default_network
+
+let database =
+  let doc = Key.Arg.info ~doc:"database to use" [ "db"; "pgdatabase" ] in
+  Key.(create "pgdatabase" Arg.(opt string "postgres" doc))
+;;
+
+let port =
+  let doc = Key.Arg.info ~doc:"port to use for postgresql" [ "p"; "pgport" ] in
+  Key.(create "pgport" Arg.(opt int 5432 doc))
+;;
+
+let hostname =
+  let doc = Key.Arg.info ~doc:"host for postgres database" [ "h"; "pghost" ] in
+  Key.(create "pghost" Arg.(required string doc))
+;;
+
+let user =
+  let doc = Key.Arg.info ~doc:"postgres user" [ "u"; "pguser" ] in
+  Key.(create "pguser" Arg.(required string doc))
+;;
+
+let password =
+  let doc = Key.Arg.info ~doc:"postgres password" [ "pgpassword" ] in
+  Key.(create "pgpassword" Arg.(required string doc))
+;;
+
+let server =
+  foreign
+    "Unikernel.Make"
+    ~keys:
+      [ Key.abstract port
+      ; Key.abstract hostname
+      ; Key.abstract user
+      ; Key.abstract password
+      ; Key.abstract database
+      ]
+    ~packages
+    (random @-> pclock @-> mclock @-> stackv4 @-> job)
+;;
+
+let () =
+  register
+    "pgx_unikernel"
+    [ server $ default_random $ default_posix_clock $ default_monotonic_clock $ stack ]
+;;
+

--- a/device-usage/pgx/unikernel.ml
+++ b/device-usage/pgx/unikernel.ml
@@ -1,0 +1,70 @@
+open Lwt.Infix
+
+module Make
+    (RANDOM : Mirage_random.S)
+    (PCLOCK : Mirage_clock.PCLOCK)
+    (MCLOCK : Mirage_clock.MCLOCK)
+    (STACK : Mirage_stack.V4) =
+struct
+  module Pgx_mirage = Pgx_lwt_mirage.Make (RANDOM) (MCLOCK) (STACK)
+  module Logs_reporter = Mirage_logs.Make (PCLOCK)
+
+  type user =
+    { id : int
+    ; email : string
+    }
+
+  let data = [ "foo@test.com"; "bar@foo.com"; "hello@test.net"; "bar@baz.test" ]
+
+  let setup_database ~port ~user ~host ~password ~database pgx () =
+    Logs.info (fun m -> m "setting up database");
+    let module P = (val pgx : Pgx_lwt.S) in
+    P.with_conn ~user ~host ~password ~port ~database (fun conn ->
+        P.execute_unit
+          conn
+          "CREATE TABLE IF NOT EXISTS users( id SERIAL PRIMARY KEY, email VARCHAR(40) \
+           NOT NULL UNIQUE );"
+        >>= fun () ->
+        let params = List.map (fun email -> Pgx.Value.[ of_string email ]) data in
+        P.execute_many
+          conn
+          ~params
+          ~query:"INSERT INTO USERS (email) VALUES ($1) ON CONFLICT (email) DO NOTHING"
+        >>= fun rows ->
+        Logs.info (fun m -> m "Inserted %d rows" (List.length rows));
+        Lwt.return_unit)
+  ;;
+
+  let get_users ~port ~user ~host ~password ~database pgx () =
+    Logs.info (fun m -> m "Fetching users");
+    let module P = (val pgx : Pgx_lwt.S) in
+    P.with_conn ~user ~host ~password ~port ~database (fun conn ->
+        P.execute_map ~params:[] conn "SELECT * FROM USERS" ~f:(fun row ->
+          match row with
+          | [ id; email ] ->
+              Lwt.return { id = Pgx.Value.to_int_exn id; email = Pgx.Value.to_string_exn email }
+          | _ -> failwith "Invalid data"))
+  ;;
+
+  let print_users users =
+    users
+    >|= fun users ->
+    List.iter
+      (fun { id; email } -> Logs.info (fun m -> m "{id = %d; email = %s}\n" id email))
+      users
+  ;;
+
+  let start _random _pclock _mclock stack =
+    Logs.(set_level (Some Info));
+    Logs_reporter.(create () |> run)
+    @@ fun () ->
+    let port = Key_gen.pgport () in
+    let host = Key_gen.pghost () in
+    let user = Key_gen.pguser () in
+    let password = Key_gen.pgpassword () in
+    let database = Key_gen.pgdatabase () in
+    let pgx = Pgx_mirage.connect stack in
+    setup_database ~port ~host ~user ~password ~database pgx ()
+    >>= fun () -> print_users (get_users ~port ~host ~user ~password ~database pgx ())
+  ;;
+end


### PR DESCRIPTION
This adds a very small example of a mirage unikernel interacting with a postgresql database using the newly published pgx_lwt_mirage library.