### PR TITLE
Fix `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ clean: $(CLEANS)
 	cd $* && $(MAKE) depend && $(MAKE)
 
 %-clean:
-	-cd $* && $(MAKE) clean
+	-cd $* && mirage clean
 	-$(RM) $*/Makefile.user
 
 %-testrun:


### PR DESCRIPTION
If there is no `Makefile` (because of some partial cleanups), `mirage clean` should always work.