### PR TITLE
Adapt to Mirage + dune

### DIFF
--- a/device-usage/block/config.ml
+++ b/device-usage/block/config.ml
@@ -1,20 +1,22 @@
 open Mirage
 
 type shellconfig = ShellConfig
-let shellconfig = Type.v ShellConfig
+let shellconfig = typ ShellConfig
 
-let config_shell =
-  let build _ =
-    Action.run_cmd Bos.Cmd.(v "dd" % "if=/dev/zero" % "of=disk.img" % "count=100000")
-  in
-  let clean _ = Action.rm (Fpath.v "disk.img") in
-  impl ~build ~clean "Functoria_runtime" shellconfig
+let config_shell = impl 
+  ~dune:(fun _ -> [Dune.stanza {|
+(rule (targets disk.img)
+ (action (run dd if=/dev/zero of=disk.img count=100000))
+)|}])
+  ~install:(fun _ -> Functoria.Install.v ~etc:[Fpath.v "disk.img"] ())
+  "shell_config"
+  shellconfig
 
 let main =
   let packages = [ package "io-page"; package "duration"; package ~build:true "bos"; package ~build:true "fpath" ] in
   main
     ~packages
-    ~extra_deps:[dep config_shell]
+    ~extra_deps:[dep config_shell] 
     "Unikernel.Main" (time @-> block @-> job)
 
 let img = Key.(if_impl is_solo5 (block_of_file "storage") (block_of_file "disk.img"))

--- a/device-usage/pgx/config.ml
+++ b/device-usage/pgx/config.ml
@@ -6,6 +6,7 @@ let packages =
   ; package "pgx_lwt_mirage"
   ; package "logs"
   ; package "mirage-logs"
+  ; package ~max:"2.2.0" "conduit" (* force conduit-mirage and conduit to have the same version. *)
   ]
 ;;
 


### PR DESCRIPTION
The changes needed in mirage-skeleton to build with the new mirage+dune toolchain.

Requires https://github.com/mirage/mirage/pull/1226 and https://github.com/mirage/mirage-dev/pull/345

Changes:
- pgx: a fix before we figure out how opam-monorepo should handle different versions of the same repository
- block: port to the new device interface