### PR TITLE
Fix Fmt deprecation warnings

### DIFF
--- a/applications/static_website_tls/config.ml
+++ b/applications/static_website_tls/config.ml
@@ -21,7 +21,7 @@ let https_port =
 
 let main =
   let packages = [
-    package "uri"; package "magic-mime"
+    package "uri"; package "magic-mime"; package ~min:"0.8.7" "fmt"
   ] in
   let keys = List.map Key.abstract [ http_port; https_port ] in
   foreign

--- a/applications/static_website_tls/dispatch.ml
+++ b/applications/static_website_tls/dispatch.ml
@@ -12,7 +12,7 @@ module Http_log = (val Logs.src_log http_src : Logs.LOG)
 
 module Dispatch (FS: Mirage_kv.RO) (S: HTTP) = struct
 
-  let failf fmt = Fmt.kstrf Lwt.fail_with fmt
+  let failf fmt = Fmt.kstr Lwt.fail_with fmt
 
   (* given a URI, find the appropriate file,
    * and construct a response with its contents. *)

--- a/device-usage/prng/config.ml
+++ b/device-usage/prng/config.ml
@@ -6,5 +6,6 @@ let () =
   let packages = [
     package "randomconv" ;
     package ~min:"0.7.0" "mirage-crypto-rng" ;
+    package ~min:"0.8.7" "fmt" ;
   ] in
   register ~packages "prng" [main $ default_random]

--- a/device-usage/prng/unikernel.ml
+++ b/device-usage/prng/unikernel.ml
@@ -15,7 +15,7 @@ module Main (R : Mirage_random.S) = struct
     Logs.info (fun m -> m "PRNG example running on %s (target %s)"
                   Sys.os_type (t_to_str t)) ;
     Logs.info (fun m -> m "using Fortuna, entropy sources: %a"
-                  Fmt.(list ~sep:(unit ", ") Mirage_crypto_rng.Entropy.pp_source)
+                  Fmt.(list ~sep:(any ", ") Mirage_crypto_rng.Entropy.pp_source)
                   (Mirage_crypto_rng.Entropy.sources ())) ;
     Logs.info (fun m -> m "32 byte random:@ %a" Cstruct.hexdump_pp (R.generate 32)) ;
     let open Randomconv in


### PR DESCRIPTION
This also adds an explicit dependency on fmt in the two packages that I modified.