### PR TITLE
Use https:// instead of git:// to build the docteur image

### DIFF
--- a/applications/docteur/config.ml
+++ b/applications/docteur/config.ml
@@ -9,6 +9,6 @@ let unikernel = foreign "Unikernel.Make"
   (console @-> kv_ro @-> job)
 
 let console = default_console
-let remote = "git://github.com/mirage/mirage"
+let remote = "https://github.com/mirage/mirage"
 
 let () = register "docteur" [ unikernel $ console $ docteur ~branch:"refs/heads/main" remote ]


### PR DESCRIPTION
A small fix when GitHub does not allow us to us `git://` protocol anymore.