### PR TITLE
Rename the docteur example to static_kv_ro

### DIFF
--- a/applications/docteur/config.ml
+++ b/applications/docteur/config.ml
@@ -11,5 +11,5 @@ let console = default_console
 let remote = "https://github.com/mirage/mirage"
 
 let () =
-  register "docteur"
+  register "static_kv_ro"
     [ unikernel $ console $ docteur ~branch:"refs/heads/main" remote ]


### PR DESCRIPTION
Spotted by @TheLortex where we generate `docteur-unix` for our unikernel `docteur` which mislead the compilation (because the `docteur-unix` package already exists).