### PR TITLE
use stackv4v6 instead of stackv4

### DIFF
--- a/device-usage/network/config.ml
+++ b/device-usage/network/config.ml
@@ -8,6 +8,6 @@ let port =
   in
   Key.(create "port" Arg.(opt int 8080 doc))
 
-let main = main ~keys:[ key port ] "Unikernel.Main" (stackv4 @-> job)
-let stack = generic_stackv4 default_network
+let main = main ~keys:[ key port ] "Unikernel.Main" (stackv4v6 @-> job)
+let stack = generic_stackv4v6 default_network
 let () = register "network" [ main $ stack ]

--- a/device-usage/network/unikernel.ml
+++ b/device-usage/network/unikernel.ml
@@ -1,26 +1,26 @@
 open Lwt.Infix
 
-module Main (S : Tcpip.Stack.V4) = struct
+module Main (S : Tcpip.Stack.V4V6) = struct
   let start s =
     let port = Key_gen.port () in
-    S.TCPV4.listen (S.tcpv4 s) ~port (fun flow ->
-        let dst, dst_port = S.TCPV4.dst flow in
+    S.TCP.listen (S.tcp s) ~port (fun flow ->
+        let dst, dst_port = S.TCP.dst flow in
         Logs.info (fun f ->
             f "new tcp connection from IP %s on port %d"
-              (Ipaddr.V4.to_string dst) dst_port);
-        S.TCPV4.read flow >>= function
+              (Ipaddr.to_string dst) dst_port);
+        S.TCP.read flow >>= function
         | Ok `Eof ->
             Logs.info (fun f -> f "Closing connection!");
             Lwt.return_unit
         | Error e ->
             Logs.warn (fun f ->
                 f "Error reading data from established connection: %a"
-                  S.TCPV4.pp_error e);
+                  S.TCP.pp_error e);
             Lwt.return_unit
         | Ok (`Data b) ->
             Logs.debug (fun f ->
                 f "read: %d bytes:\n%s" (Cstruct.length b) (Cstruct.to_string b));
-            S.TCPV4.close flow);
+            S.TCP.close flow);
 
     S.listen s
 end

--- a/device-usage/tracing/config.ml
+++ b/device-usage/tracing/config.ml
@@ -1,6 +1,6 @@
 open Mirage
 
-let main = main "Unikernel.Main" (stackv4 @-> job)
-let stack = generic_stackv4 default_network
+let main = main "Unikernel.Main" (stackv4v6 @-> job)
+let stack = generic_stackv4v6 default_network
 let tracing = mprof_trace ~size:1000000 ()
 let () = register "example" ~tracing [ main $ stack ]

--- a/device-usage/tracing/unikernel.ml
+++ b/device-usage/tracing/unikernel.ml
@@ -4,21 +4,21 @@
 
 open Lwt.Infix
 
-let target_ip = Ipaddr.V4.of_string_exn "10.0.0.1"
+let target_ip = Ipaddr.of_string_exn "10.0.0.1"
 
-module Main (S : Tcpip.Stack.V4) = struct
+module Main (S : Tcpip.Stack.V4V6) = struct
   let buffer = Io_page.get 1 |> Io_page.to_cstruct
 
   let start s =
-    let t = S.tcpv4 s in
+    let t = S.tcp s in
 
-    S.TCPV4.create_connection t (target_ip, 7001) >>= function
+    S.TCP.create_connection t (target_ip, 7001) >>= function
     | Error _err -> failwith "Connection to port 7001 failed"
     | Ok flow -> (
         let payload = Cstruct.sub buffer 0 1 in
         Cstruct.set_char payload 0 '!';
 
-        S.TCPV4.write flow payload >>= function
+        S.TCP.write flow payload >>= function
         | Error _ -> assert false
-        | Ok () -> S.TCPV4.close flow)
+        | Ok () -> S.TCP.close flow)
 end


### PR DESCRIPTION
for https://github.com/mirage/mirage/pull/1341

the only leftover is "pgx" which library (pgx-mirage) uses a stackv4. it doesn't really look maintained, is anyone using it? I'm happy to propose a PR for pgx if anyone is actually using it.