### PR TITLE
Protect repositories from the Makefile parser when they contain '#'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,11 @@ build:
 	mirage clean -f $*/config.ml
 
 comma := ,
+comment := \#
 repo-add:
 	$(foreach OVERLAY,$(subst $(comma), ,$(MIRAGE_EXTRA_REPOS)), \
 		$(eval NAME = $(shell echo --no $(OVERLAY) | cut -d: -f1)) \
-		$(eval URL  = $(shell echo --no $(OVERLAY) | cut -d: -f2-)) \
+		$(eval URL  = $(subst $(comment),\\\#,$(shell echo --no $(OVERLAY) | cut -d: -f2-))) \
 		$(OPAM) repo add $(NAME) $(URL) || $(OPAM) repo set-url $(NAME) $(URL) ; \
 	)
 


### PR DESCRIPTION
We found an error when we tried to update `mirage-opam-overlays` and it seems that `$(eval ...)` interprets `#` as a comment. When we try to set repositories to a specific commit, the Makefile does not take in account the hash of the commit due to the `#` prefix. This patch wants to solve this issue.