### PR TITLE
dune 3.7 introduced a breaking change that leads chamelon to not compile

### DIFF
--- a/device-usage/littlefs/config.ml
+++ b/device-usage/littlefs/config.ml
@@ -1,7 +1,10 @@
 open Mirage
 
 let unikernel = foreign "Unikernel.Make"
-  ~packages:[ package "hxd" ~sublibs:[ "core"; "string" ] ]
+    ~packages:[
+      package "hxd" ~sublibs:[ "core"; "string" ];
+      package ~build:true ~max:"3.7.0" "dune";
+    ]
   (random @-> console @-> kv_rw @-> job)
 
 let aes_ccm_key =


### PR DESCRIPTION
fix this by requiring < 3.7 in the littlefs unikernel

see https://github.com/mirage/mirage/pull/1401 https://github.com/mirage/mirage/pull/1399#issuecomment-1440311118