### PR TITLE
Update block device usage example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ clean: $(CLEANS)
 %-configure:
 	$(MIRAGE) configure -f $*/config.ml -t $(MODE) $(MIRAGE_FLAGS)
 
+device-usage/block-configure: device-usage/block/disk.img
+
 OPAMFILES = $(shell for i in $(TESTS); do (cd $$i/mirage; ls *.opam | sed -e 's/\.opam$$//'); done)
 
 lock:
@@ -76,6 +78,9 @@ build:
 
 %-clean:
 	mirage clean -f $*/config.ml
+
+device-usage/block/disk.img:
+	dd if=/dev/zero of=disk.img count=100000
 
 comma := ,
 comment := \#

--- a/device-usage/block/Makefile.user
+++ b/device-usage/block/Makefile.user
@@ -1,0 +1,4 @@
+build:: disk.img
+
+disk.img:
+	dd if=/dev/zero of=disk.img count=100000

--- a/device-usage/block/Makefile.user
+++ b/device-usage/block/Makefile.user
@@ -1,4 +1,0 @@
-build:: disk.img
-
-disk.img:
-	dd if=/dev/zero of=disk.img count=100000

--- a/device-usage/block/README.md
+++ b/device-usage/block/README.md
@@ -6,7 +6,7 @@ e.g. `dd`:
 
     dd if=/dev/zero of=disk.img count=100000
 
-You can build and launch the unikernel like this:
+You can build and launch the unikernel for unix like this:
 ```sh
 $ mirage configure
 $ make depends
@@ -14,3 +14,14 @@ $ make build
 $ dd if=/dev/zero of=disk.img count=100000 # image can be reused
 $ ./dist/block_test
 ```
+
+You can build and run the unikernel for solo5 hvt like so:
+```sh
+$ mirage configure -t hvt
+$ make depends
+$ make build
+$ dd if=/dev/zero of=disk.img count=100000 # image can be reused
+$ solo5-hvt --block:storage=disk.img -- ./dist/block_test.hvt
+```
+
+For the solo5 spt target it is similar to the above. Just replace occurences of `hvt` with `spt`.

--- a/device-usage/block/README.md
+++ b/device-usage/block/README.md
@@ -1,0 +1,16 @@
+# Testing the block device interface
+
+This example shows how to use block devices in MirageOS as well as some
+common pitfalls. The test requires a disk image which can be generated with
+e.g. `dd`:
+
+    dd if=/dev/zero of=disk.img count=100000
+
+You can build and launch the unikernel like this:
+```sh
+$ mirage configure
+$ make depends
+$ make build
+$ dd if=/dev/zero of=disk.img count=100000 # image can be reused
+$ ./dist/block_test
+```

--- a/device-usage/block/config.ml
+++ b/device-usage/block/config.ml
@@ -1,15 +1,8 @@
 open Mirage
 
-let main =
-  let packages =
-    [
-      package "io-page";
-      package "duration";
-    ]
-  in
-  main ~packages "Unikernel.Main" (block @-> job)
+let main = main "Unikernel.Main" (block @-> job)
 
 let img =
-  Key.(if_impl is_solo5 (block_of_file "storage") (block_of_file "disk.img"))
+  if_impl Key.is_solo5 (block_of_file "storage") (block_of_file "disk.img")
 
 let () = register "block_test" [ main $ img ]

--- a/device-usage/block/config.ml
+++ b/device-usage/block/config.ml
@@ -1,37 +1,15 @@
 open Mirage
 
-type shellconfig = ShellConfig
-
-let shellconfig = typ ShellConfig
-
-let config_shell =
-  impl
-    ~dune:(fun _ ->
-      [
-        Dune.stanza
-          {|
-(rule (targets disk.img)
- (action (run dd if=/dev/zero of=disk.img count=100000))
-)|};
-      ])
-    ~install:(fun _ -> Functoria.Install.v ~etc:[ Fpath.v "disk.img" ] ())
-    "shell_config" shellconfig
-
 let main =
   let packages =
     [
       package "io-page";
       package "duration";
-      package ~build:true "bos";
-      package ~build:true "fpath";
     ]
   in
-  main ~packages
-    ~extra_deps:[ dep config_shell ]
-    "Unikernel.Main"
-    (time @-> block @-> job)
+  main ~packages "Unikernel.Main" (block @-> job)
 
 let img =
   Key.(if_impl is_solo5 (block_of_file "storage") (block_of_file "disk.img"))
 
-let () = register "block_test" [ main $ default_time $ img ]
+let () = register "block_test" [ main $ img ]

--- a/device-usage/block/unikernel.ml
+++ b/device-usage/block/unikernel.ml
@@ -18,23 +18,20 @@ module Main (B : Mirage_block.S) = struct
 
   let rec fill_with_pattern x phrase =
     assert (String.length phrase > 0);
-    if Cstruct.length x > 0 then begin
+    if Cstruct.length x > 0 then (
       let l = min (String.length phrase) (Cstruct.length x) in
       Cstruct.blit_from_string phrase 0 x 0 l;
-      fill_with_pattern (Cstruct.shift x l) phrase
-    end
+      fill_with_pattern (Cstruct.shift x l) phrase)
 
   let alloc_dull_boy sector_size n =
     let b = Cstruct.create_unsafe (n * sector_size) in
-    List.init
-      n
-      (fun i ->
-          let sector = Cstruct.sub b (i * sector_size) sector_size in
-          let phrase =
-            sprintf "%d: All work and no play makes Dave a dull boy.\n" i
-          in
-          fill_with_pattern sector phrase;
-          sector)
+    List.init n (fun i ->
+        let sector = Cstruct.sub b (i * sector_size) sector_size in
+        let phrase =
+          sprintf "%d: All work and no play makes Dave a dull boy.\n" i
+        in
+        fill_with_pattern sector phrase;
+        sector)
 
   let check_sector_write b offset length =
     Log.debug (fun f -> f "writing %d sector(s) at %Ld\n" length offset);
@@ -42,21 +39,22 @@ module Main (B : Mirage_block.S) = struct
     B.get_info b >>= fun info ->
     let sectors = alloc_dull_boy info.sector_size length in
     B.write b offset sectors >>= fun r ->
-    begin match r with
-      | Ok () -> ()
-      | Error e ->
-        Log.err (fun m -> m "%a" B.pp_write_error e); exit 2
-    end;
+    (match r with
+    | Ok () -> ()
+    | Error e ->
+        Log.err (fun m -> m "%a" B.pp_write_error e);
+        exit 2);
     let sectors' =
       let b = Cstruct.create (length * info.sector_size) in
-      List.init length (fun i -> Cstruct.sub b (i * info.sector_size) info.sector_size)
+      List.init length (fun i ->
+          Cstruct.sub b (i * info.sector_size) info.sector_size)
     in
     B.read b offset sectors' >>= fun r ->
-    begin match r with
-      | Ok () -> ()
-      | Error e ->
-        Log.err (fun m -> m "%a" B.pp_error e); exit 2
-    end;
+    (match r with
+    | Ok () -> ()
+    | Error e ->
+        Log.err (fun m -> m "%a" B.pp_error e);
+        exit 2);
     List.iter2 (fun a b -> check_equal a b) sectors sectors';
     incr tests_passed;
     Lwt.return_unit
@@ -78,7 +76,7 @@ module Main (B : Mirage_block.S) = struct
     printf "reading %d sectors at %Ld\n%!" length offset;
     incr tests_started;
     B.get_info b >>= fun info ->
-    let sectors = [Cstruct.create (length * info.sector_size)] in
+    let sectors = [ Cstruct.create (length * info.sector_size) ] in
     Log.debug (fun f ->
         f "Expecting error output from the following operation...");
     B.read b offset sectors >|= function
@@ -92,24 +90,19 @@ module Main (B : Mirage_block.S) = struct
     Log.info (fun f -> f "%a" Mirage_block.pp_info info);
 
     check_sector_write b 0L 1 >>= fun () ->
-    check_sector_write b (Int64.sub info.size_sectors 1L) 1
-    >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 1L) 1 >>= fun () ->
     check_sector_write b 0L 2 >>= fun () ->
-    check_sector_write b (Int64.sub info.size_sectors 2L) 2
-    >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 2L) 2 >>= fun () ->
     check_sector_write b 0L 12 >>= fun () ->
-    check_sector_write b (Int64.sub info.size_sectors 12L) 12
-    >>= fun () ->
-    check_sector_write_failure b info.size_sectors 1
-    >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 12L) 12 >>= fun () ->
+    check_sector_write_failure b info.size_sectors 1 >>= fun () ->
     check_sector_write_failure b (Int64.sub info.size_sectors 11L) 12
     >>= fun () ->
-    check_sector_read_failure b info.size_sectors 1
-    >>= fun () ->
+    check_sector_read_failure b info.size_sectors 1 >>= fun () ->
     check_sector_read_failure b (Int64.sub info.size_sectors 11L) 12
     >|= fun () ->
     Log.info (fun f -> f "Test sequence finished\n");
     Log.info (fun f -> f "Total tests started: %d\n" !tests_started);
     Log.info (fun f -> f "Total tests passed:  %d\n" !tests_passed);
-    Log.info (fun f -> f "Total tests failed:  %d\n%!" !tests_failed);
+    Log.info (fun f -> f "Total tests failed:  %d\n%!" !tests_failed)
 end

--- a/device-usage/block/unikernel.ml
+++ b/device-usage/block/unikernel.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 open Printf
 
-module Main (Time : Mirage_time.S) (B : Mirage_block.S) = struct
+module Main (B : Mirage_block.S) = struct
   let log_src = Logs.Src.create "block" ~doc:"block tester"
 
   module Log = (val Logs.src_log log_src : Logs.LOG)
@@ -10,74 +10,63 @@ module Main (Time : Mirage_time.S) (B : Mirage_block.S) = struct
   let tests_passed = ref 0
   let tests_failed = ref 0
 
-  let ( >>*= ) x f =
-    x >>= function Error _ -> Lwt.fail (Failure "error") | Ok x -> f x
-
-  let fill_with_pattern x phrase =
-    for i = 0 to Cstruct.length x - 1 do
-      Cstruct.set_char x i phrase.[i mod String.length phrase]
-    done
-
-  let fill_with_zeroes x =
-    for i = 0 to Cstruct.length x - 1 do
-      Cstruct.set_uint8 x i 0
-    done
-
-  let cstruct_equal a b =
-    let check_contents a b =
-      try
-        for i = 0 to Cstruct.length a - 1 do
-          let a' = Cstruct.get_char a i in
-          let b' = Cstruct.get_char b i in
-          if a' <> b' then raise Not_found
-          (* won't escape *)
-        done;
-        true
-      with _ -> false
-    in
-    Cstruct.length a = Cstruct.length b && check_contents a b
-
   let check_equal a b =
-    if not (cstruct_equal a b) then
+    if not (Cstruct.equal a b) then
       Log.warn (fun f ->
           f "Buffers unequal: %S vs %S" (Cstruct.to_string a)
             (Cstruct.to_string b))
 
-  let alloc sector_size n =
-    let rec loop = function
-      | 0 -> []
-      | n ->
-          let page = Io_page.(to_cstruct (get 1)) in
+  let rec fill_with_pattern x phrase =
+    assert (String.length phrase > 0);
+    if Cstruct.length x > 0 then begin
+      let l = min (String.length phrase) (Cstruct.length x) in
+      Cstruct.blit_from_string phrase 0 x 0 l;
+      fill_with_pattern (Cstruct.shift x l) phrase
+    end
+
+  let alloc_dull_boy sector_size n =
+    let b = Cstruct.create_unsafe (n * sector_size) in
+    List.init
+      n
+      (fun i ->
+          let sector = Cstruct.sub b (i * sector_size) sector_size in
           let phrase =
-            sprintf "%d: All work and no play makes Dave a dull boy.\n" n
+            sprintf "%d: All work and no play makes Dave a dull boy.\n" i
           in
-          let sector = Cstruct.sub page 0 sector_size in
           fill_with_pattern sector phrase;
-          sector :: loop (n - 1)
-    in
-    loop n
+          sector)
 
-  open Mirage_block
-
-  let check_sector_write b _kind _id offset length =
-    Log.debug (fun f -> f "writing %d sectors at %Ld\n" length offset);
+  let check_sector_write b offset length =
+    Log.debug (fun f -> f "writing %d sector(s) at %Ld\n" length offset);
     incr tests_started;
     B.get_info b >>= fun info ->
-    let sectors = alloc info.sector_size length in
-    B.write b offset sectors >>*= fun () ->
-    let sectors' = alloc info.sector_size length in
-    List.iter fill_with_zeroes sectors';
-    B.read b offset sectors' >>*= fun () ->
-    List.iter (fun (a, b) -> check_equal a b) (List.combine sectors sectors');
+    let sectors = alloc_dull_boy info.sector_size length in
+    B.write b offset sectors >>= fun r ->
+    begin match r with
+      | Ok () -> ()
+      | Error e ->
+        Log.err (fun m -> m "%a" B.pp_write_error e); exit 2
+    end;
+    let sectors' =
+      let b = Cstruct.create (length * info.sector_size) in
+      List.init length (fun i -> Cstruct.sub b (i * info.sector_size) info.sector_size)
+    in
+    B.read b offset sectors' >>= fun r ->
+    begin match r with
+      | Ok () -> ()
+      | Error e ->
+        Log.err (fun m -> m "%a" B.pp_error e); exit 2
+    end;
+    List.iter2 (fun a b -> check_equal a b) sectors sectors';
     incr tests_passed;
     Lwt.return_unit
 
-  let check_sector_write_failure b _kind _id offset length =
+  let check_sector_write_failure b offset length =
     Log.debug (fun f -> f "writing %d sectors at %Ld\n" length offset);
     incr tests_started;
     B.get_info b >>= fun info ->
-    let sectors = alloc info.sector_size length in
-    Log.err (fun f ->
+    let sectors = alloc_dull_boy info.sector_size length in
+    Log.debug (fun f ->
         f "Expecting error output from the following operation...");
     B.write b offset sectors >|= function
     | Ok () ->
@@ -85,12 +74,12 @@ module Main (Time : Mirage_time.S) (B : Mirage_block.S) = struct
         incr tests_failed
     | Error _ -> incr tests_passed
 
-  let check_sector_read_failure b _kind _id offset length =
-    printf "reading %d sectors at %Ld\n" length offset;
+  let check_sector_read_failure b offset length =
+    printf "reading %d sectors at %Ld\n%!" length offset;
     incr tests_started;
     B.get_info b >>= fun info ->
-    let sectors = alloc info.sector_size length in
-    Log.err (fun f ->
+    let sectors = [Cstruct.create (length * info.sector_size)] in
+    Log.debug (fun f ->
         f "Expecting error output from the following operation...");
     B.read b offset sectors >|= function
     | Ok () ->
@@ -98,34 +87,29 @@ module Main (Time : Mirage_time.S) (B : Mirage_block.S) = struct
         incr tests_failed
     | Error _ -> incr tests_passed
 
-  let start _time b () =
+  let start b =
     B.get_info b >>= fun info ->
     Log.info (fun f -> f "%a" Mirage_block.pp_info info);
 
-    check_sector_write b "local" "51712" 0L 1 >>= fun () ->
-    check_sector_write b "local" "51712" (Int64.sub info.size_sectors 1L) 1
+    check_sector_write b 0L 1 >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 1L) 1
     >>= fun () ->
-    check_sector_write b "local" "51712" 0L 2 >>= fun () ->
-    check_sector_write b "local" "51712" (Int64.sub info.size_sectors 2L) 2
+    check_sector_write b 0L 2 >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 2L) 2
     >>= fun () ->
-    check_sector_write b "local" "51712" 0L 12 >>= fun () ->
-    check_sector_write b "local" "51712" (Int64.sub info.size_sectors 12L) 12
+    check_sector_write b 0L 12 >>= fun () ->
+    check_sector_write b (Int64.sub info.size_sectors 12L) 12
     >>= fun () ->
-    check_sector_write_failure b "local" "51712" info.size_sectors 1
+    check_sector_write_failure b info.size_sectors 1
     >>= fun () ->
-    check_sector_write_failure b "local" "51712"
-      (Int64.sub info.size_sectors 11L)
-      12
+    check_sector_write_failure b (Int64.sub info.size_sectors 11L) 12
     >>= fun () ->
-    check_sector_read_failure b "local" "51712" info.size_sectors 1
+    check_sector_read_failure b info.size_sectors 1
     >>= fun () ->
-    check_sector_read_failure b "local" "51712"
-      (Int64.sub info.size_sectors 11L)
-      12
-    >>= fun () ->
+    check_sector_read_failure b (Int64.sub info.size_sectors 11L) 12
+    >|= fun () ->
     Log.info (fun f -> f "Test sequence finished\n");
     Log.info (fun f -> f "Total tests started: %d\n" !tests_started);
     Log.info (fun f -> f "Total tests passed:  %d\n" !tests_passed);
     Log.info (fun f -> f "Total tests failed:  %d\n%!" !tests_failed);
-    Time.sleep_ns (Duration.of_sec 5)
 end


### PR DESCRIPTION
This attempts to simplify the example a bit, and updates to use newer functions from cstruct. A notable change is the disk image is not generated by mirage anymore. The generated image could be overwritten by invocations of `mirage configure` and `mirage build` which is confusing if you are modifying the example. Furthermore, it complicates the example a lot by introducing a "*custom dependency*", dune rules etc., and the `start` function takes another unit parameter due to `~extra_deps` without explanation as to why. In my personal opinion I prefer to keep (modifiable) data out of the build of the unikernel.

Finally, I'm not convinced a test suite is the best example, and I may submit another PR if I get a better idea.