### PR TITLE
Simplify noop example, revert hello example

### DIFF
--- a/tutorial/hello/config.ml
+++ b/tutorial/hello/config.ml
@@ -1,4 +1,4 @@
 open Mirage
 
-let main = main ~packages:[ package "duration" ] "Unikernel.Hello" (job @-> job)
-let () = register "hello" [ main $ noop ]
+let main = main "Unikernel.Hello" (time @-> job) ~packages:[ package "duration" ]
+let () = register "hello" [ main $ default_time ]

--- a/tutorial/hello/config.ml
+++ b/tutorial/hello/config.ml
@@ -1,4 +1,6 @@
 open Mirage
 
-let main = main "Unikernel.Hello" (time @-> job) ~packages:[ package "duration" ]
+let main =
+  main "Unikernel.Hello" (time @-> job) ~packages:[ package "duration" ]
+
 let () = register "hello" [ main $ default_time ]

--- a/tutorial/hello/unikernel.ml
+++ b/tutorial/hello/unikernel.ml
@@ -1,11 +1,12 @@
-module Hello (_ : sig end) = struct
-  let start __ =
+open Lwt.Infix
+
+module Hello (Time : Mirage_time.S) = struct
+  let start _time =
     let rec loop = function
       | 0 -> Lwt.return_unit
       | n ->
           Logs.info (fun f -> f "hello");
-          loop (n - 1)
-      (* Time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1) *)
+          Time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1)
     in
     loop 4
 end

--- a/tutorial/noop/config.ml
+++ b/tutorial/noop/config.ml
@@ -1,4 +1,1 @@
-open Mirage
-
-let main = main "Unikernel.Main" (job @-> job)
-let () = register "noop" [ main $ noop ]
+let () = Mirage.register "noop" []

--- a/tutorial/noop/unikernel.ml
+++ b/tutorial/noop/unikernel.ml
@@ -1,3 +1,0 @@
-module Main (_ : sig end) = struct
-  let start () = Lwt.return_unit
-end


### PR DESCRIPTION
The noop example can be simplified to a single line: a unikernel with no jobs. This lets us focus on explaining `Mirage.register` and talk a bit about jobs without defining any jobs, and we avoid having to explain functors straight away.

In #360 the time device was removed from the hello example (not sure why). I add it back again as we need *some* device, and we might as well explain it with a device that does something useful. Furhtermore, the named argument `~packages` is moved at the end of the call to `Mirage.main` so we unambiguously can refer to its first and second arguments.

An update to mirage-www is coming within the next few minutes.