### PR TITLE
Add game example that uses block devices

### DIFF
--- a/device-usage/disk-lottery/README.md
+++ b/device-usage/disk-lottery/README.md
@@ -1,0 +1,86 @@
+# High score game with state stored on a block device
+
+This example is a small, non-interactive game with high scores stored on a
+block device. The unikernel can store multiple game states on the block device,
+one sector per game slot.
+
+The unikernel can be built the usual way:
+```sh
+$ mirage configure
+$ make depends
+$ make build
+```
+
+The unikernel needs a disk image to read and store its state. To create a disk
+image with eight slots/sectors (assuming a sector size of 512 bytes):
+```sh
+$ dd if=/dev/zero of=disk.img count=8
+```
+
+You could run the game now, but the unikernel expects the disk to be
+initialized, so you will get an error:
+
+```sh
+$ ./dist/lottery
+2023-06-29 14:21:24 +02:00: ERR [application] Error reading state: bad magic; is this lottery data?
+```
+
+The unikernel comes with boot parameters so you can ask it to initialize or reset the game state:
+
+```sh
+$ ./dist/lottery --reset --slot 4
+2023-06-29 14:29:16 +02:00: APP [application] Reset game slot 4.
+$ ./dist/lottery --reset-all
+2023-06-29 14:25:26 +02:00: APP [application] All 8 game slots reset.
+```
+
+Now we can play! The first game is always the easiest.
+
+```sh
+$ ./dist/lottery 
+2023-06-29 14:31:38 +02:00: APP [application] YOU WON! You beat the old high score 0 with 2144007637!
+2023-06-29 14:31:38 +02:00: INF [application] Saving new game state...
+2023-06-29 14:31:38 +02:00: INF [application] Done!
+2023-06-29 14:31:38 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery 
+2023-06-29 14:31:40 +02:00: APP [application] YOU LOST! With 1466758588 you didn't beat the high score 2144007637
+2023-06-29 14:31:40 +02:00: INF [application] Saving new game state...
+2023-06-29 14:31:40 +02:00: INF [application] Done!
+2023-06-29 14:31:40 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery 
+2023-06-29 14:31:40 +02:00: APP [application] YOU WON! You beat the old high score 2144007637 with 2908584036!
+2023-06-29 14:31:40 +02:00: INF [application] Saving new game state...
+2023-06-29 14:31:40 +02:00: INF [application] Done!
+2023-06-29 14:31:40 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery 
+2023-06-29 14:31:41 +02:00: APP [application] YOU WON! You beat the old high score 2908584036 with 3112844487!
+2023-06-29 14:31:41 +02:00: INF [application] Saving new game state...
+2023-06-29 14:31:41 +02:00: INF [application] Done!
+2023-06-29 14:31:41 +02:00: APP [application] Thank you for playing! Exiting...
+```
+
+Once we get tired of the increasing difficulty of the game we can take a break
+and play the game using a different slot:
+
+```sh
+$ ./dist/lottery --slot 1
+2023-06-29 14:33:41 +02:00: APP [application] YOU WON! You beat the old high score 0 with 650987892!
+2023-06-29 14:33:41 +02:00: INF [application] Saving new game state...
+2023-06-29 14:33:41 +02:00: INF [application] Done!
+2023-06-29 14:33:41 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery --slot 1
+2023-06-29 14:33:42 +02:00: APP [application] YOU WON! You beat the old high score 650987892 with 3449332189!
+2023-06-29 14:33:42 +02:00: INF [application] Saving new game state...
+2023-06-29 14:33:42 +02:00: INF [application] Done!
+2023-06-29 14:33:42 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery --slot 1
+2023-06-29 14:33:43 +02:00: APP [application] YOU LOST! With 3185798437 you didn't beat the high score 3449332189
+2023-06-29 14:33:43 +02:00: INF [application] Saving new game state...
+2023-06-29 14:33:43 +02:00: INF [application] Done!
+2023-06-29 14:33:43 +02:00: APP [application] Thank you for playing! Exiting...
+$ ./dist/lottery --slot 1
+2023-06-29 14:33:44 +02:00: APP [application] YOU LOST! With 458063507 you didn't beat the high score 3449332189
+2023-06-29 14:33:44 +02:00: INF [application] Saving new game state...
+2023-06-29 14:33:44 +02:00: INF [application] Done!
+2023-06-29 14:33:44 +02:00: APP [application] Thank you for playing! Exiting...
+```

--- a/device-usage/disk-lottery/config.ml
+++ b/device-usage/disk-lottery/config.ml
@@ -1,0 +1,24 @@
+open Mirage
+
+let reset_all =
+  let doc = Key.Arg.info ~doc:"Reset all state on disk and quit" [ "reset-all" ] in
+  Key.(create "reset-all" (Arg.flag ~stage:`Run doc))
+
+let sector =
+  let doc = Key.Arg.info ~doc:"Sector to read and write game state to" [ "slot" ] in
+  Key.(create "sector" (Arg.opt ~stage:`Run Arg.int64 0L doc))
+
+let reset =
+  let doc = Key.Arg.info ~doc:"Reset the state on disk at the specified slot \
+  (using --slot, default 0) and quit" [ "reset" ] in
+  Key.(create "reset" (Arg.flag ~stage:`Run doc))
+
+let main =
+  main "Unikernel.Main" (block @-> random @-> job)
+    ~keys:[ key reset_all ; key reset ; key sector ]
+    ~packages:[ package "checkseum"; package "cstruct"; package "fmt" ]
+
+let img =
+  if_impl Key.is_solo5 (block_of_file "storage") (block_of_file "disk.img")
+
+let () = register "lottery" [ main $ img $ default_random ]

--- a/device-usage/disk-lottery/config.ml
+++ b/device-usage/disk-lottery/config.ml
@@ -1,21 +1,31 @@
 open Mirage
 
 let reset_all =
-  let doc = Key.Arg.info ~doc:"Reset all state on disk and quit" [ "reset-all" ] in
+  let doc =
+    Key.Arg.info ~doc:"Reset all state on disk and quit" [ "reset-all" ]
+  in
   Key.(create "reset-all" (Arg.flag ~stage:`Run doc))
 
 let sector =
-  let doc = Key.Arg.info ~doc:"Sector to read and write game state to" [ "slot" ] in
+  let doc =
+    Key.Arg.info ~doc:"Sector to read and write game state to" [ "slot" ]
+  in
   Key.(create "sector" (Arg.opt ~stage:`Run Arg.int64 0L doc))
 
 let reset =
-  let doc = Key.Arg.info ~doc:"Reset the state on disk at the specified slot \
-  (using --slot, default 0) and quit" [ "reset" ] in
+  let doc =
+    Key.Arg.info
+      ~doc:
+        "Reset the state on disk at the specified slot (using --slot, default \
+         0) and quit"
+      [ "reset" ]
+  in
   Key.(create "reset" (Arg.flag ~stage:`Run doc))
 
 let main =
-  main "Unikernel.Main" (block @-> random @-> job)
-    ~keys:[ key reset_all ; key reset ; key sector ]
+  main "Unikernel.Main"
+    (block @-> random @-> job)
+    ~keys:[ key reset_all; key reset; key sector ]
     ~packages:[ package "checkseum"; package "cstruct"; package "fmt" ]
 
 let img =

--- a/device-usage/disk-lottery/lotto.ml
+++ b/device-usage/disk-lottery/lotto.ml
@@ -1,0 +1,75 @@
+type state = { hiscore : int32 }
+
+let initial_state = { hiscore = Int32.zero }
+
+type game =
+  | New_hiscore of { hiscore : int32; old_hiscore : int32 }
+  | Tie of int32
+  | Loss of { loser : int32; hiscore : int32 }
+
+let pp_game ppf = function
+  | New_hiscore { hiscore; old_hiscore } ->
+    Fmt.pf ppf "YOU WON! You beat the old high score %lu with %lu!" old_hiscore hiscore
+  | Tie hiscore ->
+    Fmt.pf ppf "TIE! You tied with the high score %lu" hiscore
+  | Loss { loser; hiscore } ->
+    Fmt.pf ppf "YOU LOST! With %lu you didn't beat the high score %lu" loser hiscore
+
+let play state draw : game * state =
+  if draw = state.hiscore then
+    Tie draw, state
+  else if Int32.unsigned_compare draw state.hiscore > 0 then
+    let hiscore = draw in
+    New_hiscore { hiscore; old_hiscore = state.hiscore }, { hiscore }
+  else
+    Loss { loser = draw; hiscore = state.hiscore }, state
+
+(* The format is: "LOTO" || uint32 hiscore || uint32 crc32 *)
+let magic = "LOTO"
+let magic_offset = 0
+let magic_len = 4
+
+let hiscore_offset = 4
+let hiscore_len = 4
+
+let crc_offset = 8
+let crc_len = 4
+
+let len = 12
+let () = assert (len = magic_len + hiscore_len + crc_len)
+
+let digest_cstruct buf =
+  let crc32 =
+    Checkseum.Crc32.digest_bigstring
+      buf.Cstruct.buffer buf.off buf.len
+      Optint.zero
+  in
+  Checkseum.Crc32.to_int32 crc32
+
+let marshal buf { hiscore } =
+  if Cstruct.length buf < len then
+    invalid_arg "Lotto.marshal";
+  Cstruct.blit_from_string magic 0 buf magic_offset magic_len;
+  Cstruct.BE.set_uint32 buf hiscore_offset hiscore;
+  let checksum = digest_cstruct (Cstruct.sub buf 0 (magic_len + hiscore_len)) in
+  Cstruct.BE.set_uint32 buf crc_offset checksum;
+  Cstruct.memset (Cstruct.shift buf len) 0
+
+let unmarshal buf =
+  let ( let* ) = Result.bind in
+  if Cstruct.length buf < len then
+    invalid_arg "Lotto.unmarshal";
+  let* () =
+    if String.equal magic
+        (Cstruct.to_string buf ~off:magic_offset ~len:magic_len) then
+      Ok ()
+    else Error (`Msg "bad magic; is this lottery data?")
+  in
+  let checksum = Cstruct.BE.get_uint32 buf crc_offset in
+  let checksum' = digest_cstruct (Cstruct.sub buf 0 (magic_len + hiscore_len)) in
+  let* () =
+    if Int32.equal checksum checksum' then
+      Ok ()
+    else Error (`Msg "bad checksum; possible data corruption")
+  in
+  Ok { hiscore = Cstruct.BE.get_uint32 buf hiscore_offset }

--- a/device-usage/disk-lottery/lotto.ml
+++ b/device-usage/disk-lottery/lotto.ml
@@ -9,46 +9,40 @@ type game =
 
 let pp_game ppf = function
   | New_hiscore { hiscore; old_hiscore } ->
-    Fmt.pf ppf "YOU WON! You beat the old high score %lu with %lu!" old_hiscore hiscore
-  | Tie hiscore ->
-    Fmt.pf ppf "TIE! You tied with the high score %lu" hiscore
+      Fmt.pf ppf "YOU WON! You beat the old high score %lu with %lu!"
+        old_hiscore hiscore
+  | Tie hiscore -> Fmt.pf ppf "TIE! You tied with the high score %lu" hiscore
   | Loss { loser; hiscore } ->
-    Fmt.pf ppf "YOU LOST! With %lu you didn't beat the high score %lu" loser hiscore
+      Fmt.pf ppf "YOU LOST! With %lu you didn't beat the high score %lu" loser
+        hiscore
 
 let play state draw : game * state =
-  if draw = state.hiscore then
-    Tie draw, state
+  if draw = state.hiscore then (Tie draw, state)
   else if Int32.unsigned_compare draw state.hiscore > 0 then
     let hiscore = draw in
-    New_hiscore { hiscore; old_hiscore = state.hiscore }, { hiscore }
-  else
-    Loss { loser = draw; hiscore = state.hiscore }, state
+    (New_hiscore { hiscore; old_hiscore = state.hiscore }, { hiscore })
+  else (Loss { loser = draw; hiscore = state.hiscore }, state)
 
 (* The format is: "LOTO" || uint32 hiscore || uint32 crc32 *)
 let magic = "LOTO"
 let magic_offset = 0
 let magic_len = 4
-
 let hiscore_offset = 4
 let hiscore_len = 4
-
 let crc_offset = 8
 let crc_len = 4
-
 let len = 12
 let () = assert (len = magic_len + hiscore_len + crc_len)
 
 let digest_cstruct buf =
   let crc32 =
-    Checkseum.Crc32.digest_bigstring
-      buf.Cstruct.buffer buf.off buf.len
+    Checkseum.Crc32.digest_bigstring buf.Cstruct.buffer buf.off buf.len
       Optint.zero
   in
   Checkseum.Crc32.to_int32 crc32
 
 let marshal buf { hiscore } =
-  if Cstruct.length buf < len then
-    invalid_arg "Lotto.marshal";
+  if Cstruct.length buf < len then invalid_arg "Lotto.marshal";
   Cstruct.blit_from_string magic 0 buf magic_offset magic_len;
   Cstruct.BE.set_uint32 buf hiscore_offset hiscore;
   let checksum = digest_cstruct (Cstruct.sub buf 0 (magic_len + hiscore_len)) in
@@ -57,19 +51,20 @@ let marshal buf { hiscore } =
 
 let unmarshal buf =
   let ( let* ) = Result.bind in
-  if Cstruct.length buf < len then
-    invalid_arg "Lotto.unmarshal";
+  if Cstruct.length buf < len then invalid_arg "Lotto.unmarshal";
   let* () =
-    if String.equal magic
-        (Cstruct.to_string buf ~off:magic_offset ~len:magic_len) then
-      Ok ()
+    if
+      String.equal magic
+        (Cstruct.to_string buf ~off:magic_offset ~len:magic_len)
+    then Ok ()
     else Error (`Msg "bad magic; is this lottery data?")
   in
   let checksum = Cstruct.BE.get_uint32 buf crc_offset in
-  let checksum' = digest_cstruct (Cstruct.sub buf 0 (magic_len + hiscore_len)) in
+  let checksum' =
+    digest_cstruct (Cstruct.sub buf 0 (magic_len + hiscore_len))
+  in
   let* () =
-    if Int32.equal checksum checksum' then
-      Ok ()
+    if Int32.equal checksum checksum' then Ok ()
     else Error (`Msg "bad checksum; possible data corruption")
   in
   Ok { hiscore = Cstruct.BE.get_uint32 buf hiscore_offset }

--- a/device-usage/disk-lottery/lotto.mli
+++ b/device-usage/disk-lottery/lotto.mli
@@ -1,0 +1,15 @@
+type state
+
+type game
+
+val initial_state : state
+
+val pp_game : Format.formatter -> game -> unit
+
+val play : state -> int32 -> game * state
+
+val len : int
+
+val marshal : Cstruct.t -> state -> unit
+
+val unmarshal : Cstruct.t -> (state, [> `Msg of string]) result

--- a/device-usage/disk-lottery/lotto.mli
+++ b/device-usage/disk-lottery/lotto.mli
@@ -1,15 +1,9 @@
 type state
-
 type game
 
 val initial_state : state
-
 val pp_game : Format.formatter -> game -> unit
-
 val play : state -> int32 -> game * state
-
 val len : int
-
 val marshal : Cstruct.t -> state -> unit
-
-val unmarshal : Cstruct.t -> (state, [> `Msg of string]) result
+val unmarshal : Cstruct.t -> (state, [> `Msg of string ]) result


### PR DESCRIPTION
The game is a random "dice" game. A random number is rolled, and the number is compared with the number stored in the game state. If it's higher, you win. The new high score is stored on the block device. Each sector is a slot to store game state in, so multiple games and be played.

I think this example is more interesting than the existing block device example. The existing example does not leverage that the block device is persistent, and would work just as well with an ephemeral in-memory "block device".