### PR TITLE
revert the Key.v -> key renaming, which doesn't work with latest release of mirage

### DIFF
--- a/applications/static_website_tls/config.ml
+++ b/applications/static_website_tls/config.ml
@@ -23,7 +23,7 @@ let https_port =
 
 let main =
   let packages = [ package "uri"; package "magic-mime" ] in
-  let keys = List.map key [ http_port; https_port ] in
+  let keys = List.map Key.v [ http_port; https_port ] in
   main ~packages ~keys "Dispatch.HTTPS"
     (pclock @-> kv_ro @-> kv_ro @-> http @-> job)
 

--- a/device-usage/disk-lottery/config.ml
+++ b/device-usage/disk-lottery/config.ml
@@ -25,7 +25,7 @@ let reset =
 let main =
   main "Unikernel.Main"
     (block @-> random @-> job)
-    ~keys:[ key reset_all; key reset; key sector ]
+    ~keys:[ Key.v reset_all; Key.v reset; Key.v sector ]
     ~packages:[ package "checkseum"; package "cstruct"; package "fmt" ]
 
 let img =

--- a/device-usage/http-fetch/config.ml
+++ b/device-usage/http-fetch/config.ml
@@ -6,7 +6,7 @@ let uri =
 
 let client =
   let packages = [ package "cohttp-mirage"; package "duration" ] in
-  main ~keys:[ key uri ] ~packages "Unikernel.Client" @@ http_client @-> job
+  main ~keys:[ Key.v uri ] ~packages "Unikernel.Client" @@ http_client @-> job
 
 let () =
   let stack = generic_stackv4v6 default_network in

--- a/device-usage/network/config.ml
+++ b/device-usage/network/config.ml
@@ -8,6 +8,6 @@ let port =
   in
   Key.(create "port" Arg.(opt ~stage:`Run int 8080 doc))
 
-let main = main ~keys:[ key port ] "Unikernel.Main" (stackv4v6 @-> job)
+let main = main ~keys:[ Key.v port ] "Unikernel.Main" (stackv4v6 @-> job)
 let stack = generic_stackv4v6 default_network
 let () = register "network" [ main $ stack ]

--- a/device-usage/pgx/config.ml
+++ b/device-usage/pgx/config.ml
@@ -35,7 +35,8 @@ let password =
 
 let server =
   main "Unikernel.Make"
-    ~keys:[ Key.v port; Key.v hostname; Key.v user; Key.v password; Key.v database ]
+    ~keys:
+      [ Key.v port; Key.v hostname; Key.v user; Key.v password; Key.v database ]
     ~packages
     (random @-> time @-> pclock @-> mclock @-> stackv4 @-> job)
 

--- a/device-usage/pgx/config.ml
+++ b/device-usage/pgx/config.ml
@@ -35,7 +35,7 @@ let password =
 
 let server =
   main "Unikernel.Make"
-    ~keys:[ key port; key hostname; key user; key password; key database ]
+    ~keys:[ Key.v port; Key.v hostname; Key.v user; Key.v password; Key.v database ]
     ~packages
     (random @-> time @-> pclock @-> mclock @-> stackv4 @-> job)
 

--- a/tutorial/hello-key/config.ml
+++ b/tutorial/hello-key/config.ml
@@ -6,7 +6,7 @@ let hello =
 
 let main =
   main
-    ~keys:[ key hello ]
+    ~keys:[ Key.v hello ]
     ~packages:[ package "duration" ]
     "Unikernel.Hello" (time @-> job)
 


### PR DESCRIPTION
//cc @samoht 