### PR TITLE
applications/static_website_tls: use standard ports

### DIFF
--- a/applications/static_website_tls/config.ml
+++ b/applications/static_website_tls/config.ml
@@ -9,7 +9,7 @@ let https_srv = cohttp_server @@ conduit_direct ~tls:true stack
 
 let http_port =
   let doc = Key.Arg.info ~doc:"Listening HTTP port." [ "http" ] in
-  Key.(create "http_port" Arg.(opt ~stage:`Run int 8080 doc))
+  Key.(create "http_port" Arg.(opt ~stage:`Run int 80 doc))
 
 let certs_key = Key.(value @@ kv_ro ~group:"certs" ())
 
@@ -19,7 +19,7 @@ let certs = generic_kv_ro ~key:certs_key "tls"
 
 let https_port =
   let doc = Key.Arg.info ~doc:"Listening HTTPS port." [ "https" ] in
-  Key.(create "https_port" Arg.(opt ~stage:`Run int 4433 doc))
+  Key.(create "https_port" Arg.(opt ~stage:`Run int 443 doc))
 
 let main =
   let packages = [ package "uri"; package "magic-mime" ] in


### PR DESCRIPTION
Using non-standard ports 8080 and 4433 are perhaps nice for the Unix target where the standard ports are privileged, but for all other targets they are less desirable.