### PR TITLE
Add simple dream server skeleton to applications

### DIFF
--- a/applications/dream/config.ml
+++ b/applications/dream/config.ml
@@ -1,0 +1,11 @@
+open Mirage
+
+let packages = [ package "dream-mirage" ]
+
+let http =
+  main "Unikernel.Make" ~packages (pclock @-> time @-> stackv4v6 @-> job)
+
+let default_stack = generic_stackv4v6 default_network
+
+let () =
+  register "dream" [ http $ default_posix_clock $ default_time $ default_stack ]

--- a/applications/dream/unikernel.ml
+++ b/applications/dream/unikernel.ml
@@ -1,0 +1,17 @@
+module Make
+    (Pclock : Mirage_clock.PCLOCK)
+    (Time : Mirage_time.S)
+    (Stack : Tcpip.Stack.V4V6) =
+struct
+  module Dream = Dream__mirage.Mirage.Make (Pclock) (Time) (Stack)
+
+  let start _pclock _time stack =
+    Dream.http ~port:8080 (Stack.tcp stack)
+    @@ Dream.logger
+    @@ Dream.router
+         [
+           Dream.get "/" (fun _ -> Dream.html "Good morning, world!");
+           Dream.get "/echo/:word" (fun request ->
+               Dream.html (Dream.param request "word"));
+         ]
+end


### PR DESCRIPTION
Dream is a popular web server, and it could be nice to have a setup to start with.

An example is already available in [Dream's examples](https://github.com/aantron/dream/tree/master/example/w-mirage), but having it in the skeleton makes it more discoverable for people coming from the [mirageos tutorial](https://mirage.io/docs/hello-world).