### PR TITLE
mirage-time is now variant :)

### DIFF
--- a/applications/dhcp/config.ml
+++ b/applications/dhcp/config.ml
@@ -9,8 +9,10 @@ let packages =
     package ~min:"3.0.0" "ethernet";
   ]
 
-let main = main "Unikernel.Main" ~packages (network @-> mclock @-> time @-> job)
+let main =
+  let extra_deps = [ dep default_time ] in
+  main ~extra_deps "Unikernel.Main" ~packages (network @-> mclock @-> job)
 
 let () =
   register "dhcp"
-    [ main $ default_network $ default_monotonic_clock $ default_time ]
+    [ main $ default_network $ default_monotonic_clock ]

--- a/applications/dhcp/unikernel.ml
+++ b/applications/dhcp/unikernel.ml
@@ -2,11 +2,10 @@ open Lwt.Infix
 
 module Main
     (N : Mirage_net.S)
-    (MClock : Mirage_clock.MCLOCK)
-    (Time : Mirage_time.S) =
+    (MClock : Mirage_clock.MCLOCK) =
 struct
   module E = Ethernet.Make (N)
-  module A = Arp.Make (E) (Time)
+  module A = Arp.Make (E)
   module DC = Dhcp_config
 
   let of_interest dest net =

--- a/device-usage/clock/config.ml
+++ b/device-usage/clock/config.ml
@@ -2,9 +2,10 @@
 open Mirage
 
 let main =
+  let extra_deps = [ dep default_time ] in
   let packages = [ package "duration" ] in
-  main ~packages "Unikernel.Main" (time @-> pclock @-> mclock @-> job)
+  main ~extra_deps ~packages "Unikernel.Main" (pclock @-> mclock @-> job)
 
 let () =
   register "speaking_clock"
-    [ main $ default_time $ default_posix_clock $ default_monotonic_clock ]
+    [ main $ default_posix_clock $ default_monotonic_clock ]

--- a/device-usage/clock/unikernel.ml
+++ b/device-usage/clock/unikernel.ml
@@ -1,11 +1,10 @@
 open Lwt.Infix
 
 module Main
-    (Time : Mirage_time.S)
     (PClock : Mirage_clock.PCLOCK)
     (MClock : Mirage_clock.MCLOCK) =
 struct
-  let start _time pclock mclock =
+  let start pclock mclock _time =
     let rec speak pclock mclock () =
       let current_time = PClock.now_d_ps pclock |> Ptime.v in
       let tz = PClock.current_tz_offset_s pclock in
@@ -15,7 +14,8 @@ struct
           m "At the stroke, the time will be %a \x07 *BEEP*"
             (Ptime.pp_human ?tz_offset_s:tz ())
             current_time);
-      Time.sleep_ns (Duration.of_sec 1) >>= fun () -> speak pclock mclock ()
+      Mirage_time.sleep_ns (Duration.of_sec 1) >>= fun () ->
+      speak pclock mclock ()
     in
     speak pclock mclock ()
 end

--- a/tutorial/hello-key/config.ml
+++ b/tutorial/hello-key/config.ml
@@ -3,5 +3,6 @@ open Mirage
 
 let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.hello" ]
 let packages = [ package "duration" ]
-let main = main ~runtime_args ~packages "Unikernel.Hello" (time @-> job)
-let () = register "hello-key" [ main $ default_time ]
+let extra_deps = [ dep default_time ]
+let main = main ~extra_deps ~runtime_args ~packages "Unikernel" job
+let () = register "hello-key" [ main ]

--- a/tutorial/hello-key/unikernel.ml
+++ b/tutorial/hello-key/unikernel.ml
@@ -5,13 +5,11 @@ let hello =
   let doc = Arg.info ~doc:"How to say hello." [ "hello" ] in
   Arg.(value & opt string "Hello World!" doc)
 
-module Hello (Time : Mirage_time.S) = struct
-  let start _time hello =
-    let rec loop = function
-      | 0 -> Lwt.return_unit
-      | n ->
-          Logs.info (fun f -> f "%s" hello);
-          Time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1)
-    in
-    loop 4
-end
+let start () hello =
+  let rec loop = function
+    | 0 -> Lwt.return_unit
+    | n ->
+      Logs.info (fun f -> f "%s" hello);
+      Mirage_time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1)
+  in
+  loop 4

--- a/tutorial/hello/config.ml
+++ b/tutorial/hello/config.ml
@@ -2,6 +2,7 @@
 open Mirage
 
 let main =
-  main "Unikernel.Hello" (time @-> job) ~packages:[ package "duration" ]
+  let extra_deps = [ dep default_time ] in
+  main ~extra_deps "Unikernel" job ~packages:[ package "duration" ]
 
-let () = register "hello" [ main $ default_time ]
+let () = register "hello" [ main ]

--- a/tutorial/hello/unikernel.ml
+++ b/tutorial/hello/unikernel.ml
@@ -1,12 +1,10 @@
 open Lwt.Infix
 
-module Hello (Time : Mirage_time.S) = struct
-  let start _time =
-    let rec loop = function
-      | 0 -> Lwt.return_unit
-      | n ->
-          Logs.info (fun f -> f "hello");
-          Time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1)
-    in
-    loop 4
-end
+let start _time =
+  let rec loop = function
+    | 0 -> Lwt.return_unit
+    | n ->
+      Logs.info (fun f -> f "hello");
+      Mirage_time.sleep_ns (Duration.of_sec 1) >>= fun () -> loop (n - 1)
+  in
+  loop 4

--- a/tutorial/lwt/echo_server/config.ml
+++ b/tutorial/lwt/echo_server/config.ml
@@ -3,6 +3,7 @@ open Mirage
 
 let main =
   let packages = [ package "duration"; package ~max:"0.2.0" "randomconv" ] in
-  main ~packages "Unikernel.Echo_server" (time @-> random @-> job)
+  let extra_deps = [ dep default_time ] in
+  main ~extra_deps ~packages "Unikernel.Echo_server" (random @-> job)
 
-let () = register "echo_server" [ main $ default_time $ default_random ]
+let () = register "echo_server" [ main $ default_random ]

--- a/tutorial/lwt/echo_server/unikernel.ml
+++ b/tutorial/lwt/echo_server/unikernel.ml
@@ -1,13 +1,13 @@
 open Lwt.Infix
 
-module Echo_server (Time : Mirage_time.S) (R : Mirage_random.S) = struct
+module Echo_server (R : Mirage_random.S) = struct
   let generate n = R.generate n
 
   let read_line () =
-    Time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:2500 generate))
+    Mirage_time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:2500 generate))
     >|= fun () -> String.make (Randomconv.int ~bound:20 generate) 'a'
 
-  let start _time _r =
+  let start _r _time =
     let rec echo_server = function
       | 0 -> Lwt.return ()
       | n ->

--- a/tutorial/lwt/heads1/config.ml
+++ b/tutorial/lwt/heads1/config.ml
@@ -2,6 +2,7 @@
 open Mirage
 
 let main =
-  main ~packages:[ package "duration" ] "Unikernel.Heads1" (time @-> job)
+  let extra_deps = [ dep default_time ] in
+  main ~extra_deps ~packages:[ package "duration" ] "Unikernel" job
 
-let () = register "heads1" [ main $ default_time ]
+let () = register "heads1" [ main ]

--- a/tutorial/lwt/heads1/unikernel.ml
+++ b/tutorial/lwt/heads1/unikernel.ml
@@ -1,13 +1,11 @@
 open Lwt.Infix
 
-module Heads1 (Time : Mirage_time.S) = struct
-  let start _time =
-    Lwt.join
-      [
-        ( Time.sleep_ns (Duration.of_sec 1) >|= fun () ->
-          Logs.info (fun m -> m "Heads") );
-        ( Time.sleep_ns (Duration.of_sec 2) >|= fun () ->
-          Logs.info (fun m -> m "Tails") );
-      ]
-    >|= fun () -> Logs.info (fun m -> m "Finished")
-end
+let start _time =
+  Lwt.join
+    [
+      ( Mirage_time.sleep_ns (Duration.of_sec 1) >|= fun () ->
+        Logs.info (fun m -> m "Heads") );
+      ( Mirage_time.sleep_ns (Duration.of_sec 2) >|= fun () ->
+        Logs.info (fun m -> m "Tails") );
+    ]
+  >|= fun () -> Logs.info (fun m -> m "Finished")

--- a/tutorial/lwt/heads2/config.ml
+++ b/tutorial/lwt/heads2/config.ml
@@ -2,8 +2,10 @@
 open Mirage
 
 let main =
+  let extra_deps = [ dep default_time ] in
   main
+    ~extra_deps
     ~packages:[ package "duration"; package "randomconv" ]
-    "Unikernel.Heads2" (time @-> job)
+    "Unikernel" job
 
-let () = register "heads2" [ main $ default_time ]
+let () = register "heads2" [ main ]

--- a/tutorial/lwt/heads2/unikernel.ml
+++ b/tutorial/lwt/heads2/unikernel.ml
@@ -1,14 +1,12 @@
 open Lwt.Infix
 
-module Heads2 (Time : Mirage_time.S) = struct
-  let start _time =
-    let heads =
-      Time.sleep_ns (Duration.of_sec 1) >|= fun () ->
-      Logs.info (fun m -> m "Heads")
-    in
-    let tails =
-      Time.sleep_ns (Duration.of_sec 2) >|= fun () ->
-      Logs.info (fun m -> m "Tails")
-    in
-    heads <&> tails >|= fun () -> Logs.info (fun m -> m "Finished")
-end
+let start _time =
+  let heads =
+    Mirage_time.sleep_ns (Duration.of_sec 1) >|= fun () ->
+    Logs.info (fun m -> m "Heads")
+  in
+  let tails =
+    Mirage_time.sleep_ns (Duration.of_sec 2) >|= fun () ->
+    Logs.info (fun m -> m "Tails")
+  in
+  heads <&> tails >|= fun () -> Logs.info (fun m -> m "Finished")

--- a/tutorial/lwt/timeout1/config.ml
+++ b/tutorial/lwt/timeout1/config.ml
@@ -2,9 +2,11 @@
 open Mirage
 
 let main =
+  let extra_deps = [ dep default_time ] in
   main
+    ~extra_deps
     ~packages:[ package "duration"; package ~max:"0.2.0" "randomconv" ]
     "Unikernel.Timeout1"
-    (time @-> random @-> job)
+    (random @-> job)
 
-let () = register "timeout1" [ main $ default_time $ default_random ]
+let () = register "timeout1" [ main $ default_random ]

--- a/tutorial/lwt/timeout1/unikernel.ml
+++ b/tutorial/lwt/timeout1/unikernel.ml
@@ -1,8 +1,8 @@
 open Lwt.Infix
 
-module Timeout1 (Time : Mirage_time.S) (R : Mirage_random.S) = struct
+module Timeout1 (R : Mirage_random.S) = struct
   let timeout delay t =
-    Time.sleep_ns delay >>= fun () ->
+    Mirage_time.sleep_ns delay >>= fun () ->
     match Lwt.state t with
     | Lwt.Sleep ->
         Lwt.cancel t;
@@ -12,9 +12,9 @@ module Timeout1 (Time : Mirage_time.S) (R : Mirage_random.S) = struct
 
   let generate i = R.generate i
 
-  let start _time _r =
+  let start _r _time =
     let t =
-      Time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:3000 generate))
+      Mirage_time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:3000 generate))
       >|= fun () -> "Heads"
     in
     timeout (Duration.of_sec 2) t >|= function

--- a/tutorial/lwt/timeout2/config.ml
+++ b/tutorial/lwt/timeout2/config.ml
@@ -2,9 +2,10 @@
 open Mirage
 
 let main =
-  main
+  let extra_deps = [ dep default_time ] in
+  main ~extra_deps
     ~packages:[ package "duration"; package ~max:"0.2.0" "randomconv" ]
     "Unikernel.Timeout2"
-    (time @-> random @-> job)
+    (random @-> job)
 
-let () = register "timeout2" [ main $ default_time $ default_random ]
+let () = register "timeout2" [ main $ default_random ]

--- a/tutorial/lwt/timeout2/unikernel.ml
+++ b/tutorial/lwt/timeout2/unikernel.ml
@@ -1,15 +1,15 @@
 open Lwt.Infix
 
-module Timeout2 (Time : Mirage_time.S) (R : Mirage_random.S) = struct
+module Timeout2 (R : Mirage_random.S) = struct
   let timeout delay t =
-    let tmout = Time.sleep_ns delay in
+    let tmout = Mirage_time.sleep_ns delay in
     Lwt.pick [ (tmout >|= fun () -> None); (t >|= fun v -> Some v) ]
 
   let generate i = R.generate i
 
-  let start _time _r =
+  let start _r _time =
     let t =
-      Time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:3000 generate))
+      Mirage_time.sleep_ns (Duration.of_ms (Randomconv.int ~bound:3000 generate))
       >|= fun () -> "Heads"
     in
     timeout (Duration.of_sec 2) t >|= function


### PR DESCRIPTION
Instead of functorising over Mirage_time.S, we use dune variants to select the target-specific implementation.