### PR TITLE
Add Mirage bounds in config.ml (since mirage 4.4.1, mirage/mirage#1466)

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.1
+version = 0.26.2
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ necessary:
     $ eval `opam config env`
 ```
 
-- Please ensure that your Mirage command-line version is at least 4.4.0 before
+- Please ensure that your Mirage command-line version is at least 4.5.0 before
 proceeding:
 
 ```
     $ mirage --version
-    4.4.0
+    4.5.0
 ```
 
 ## Trivial example
@@ -104,10 +104,6 @@ directly.
 The boot target is selected via the `-t` flag. The default target is `unix`.
 Depending on what devices are present in `config.ml`, there may be additional
 configuration options for the unikernel.  To list the options,
-
-**Note:** the option `hvt` needs `mirage ≥ 3.2.0` - which you can get via
-[opam 2](https://opam.ocaml.org/doc/Install.html)
-
 
 ```
     $ mirage help configure

--- a/applications/crypto/config.ml
+++ b/applications/crypto/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let packages =

--- a/applications/dhcp/config.ml
+++ b/applications/dhcp/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let packages =

--- a/applications/dns/config.ml
+++ b/applications/dns/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let timeout = Runtime_arg.create ~pos:__POS__ "Unikernel.timeout"

--- a/applications/docteur/config.ml
+++ b/applications/docteur/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.filename" ]

--- a/applications/git/config.ml
+++ b/applications/git/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 type hash = Hash

--- a/applications/http/config.ml
+++ b/applications/http/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let port = Runtime_arg.create ~pos:__POS__ "Unikernel.port"

--- a/applications/static_website_tls/config.ml
+++ b/applications/static_website_tls/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let stack = generic_stackv4v6 default_network

--- a/device-usage/block/config.ml
+++ b/device-usage/block/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main = main "Unikernel.Main" (block @-> job)

--- a/device-usage/clock/config.ml
+++ b/device-usage/clock/config.ml
@@ -1,6 +1,9 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
-let main = main "Unikernel.Main" (time @-> pclock @-> mclock @-> job)
+let main =
+  let packages = [ package "duration" ] in
+  main ~packages "Unikernel.Main" (time @-> pclock @-> mclock @-> job)
 
 let () =
   register "speaking_clock"

--- a/device-usage/clock/unikernel.ml
+++ b/device-usage/clock/unikernel.ml
@@ -1,30 +1,21 @@
 open Lwt.Infix
 
-let log = Logs.Src.create "speaking clock" ~doc:"At the third stroke..."
-
-module Log = (val Logs.src_log log : Logs.LOG)
-
 module Main
     (Time : Mirage_time.S)
     (PClock : Mirage_clock.PCLOCK)
     (MClock : Mirage_clock.MCLOCK) =
 struct
-  let str_of_time (posix_time, timezone) =
-    Format.asprintf "%a" (Ptime.pp_human ?tz_offset_s:timezone ()) posix_time
-
   let start _time pclock mclock =
     let rec speak pclock mclock () =
       let current_time = PClock.now_d_ps pclock |> Ptime.v in
       let tz = PClock.current_tz_offset_s pclock in
-      let str =
-        Printf.sprintf
-          "%Lu nanoseconds have elapsed. \n\
-          \ At the stroke, the time will be %s \x07 *BEEP*"
-          (MClock.elapsed_ns mclock)
-        @@ str_of_time (current_time, tz)
-      in
-      Log.info (fun f -> f "%s" str);
-      Time.sleep_ns 1_000_000_000L >>= fun () -> speak pclock mclock ()
+      Logs.app (fun m ->
+          m "%Lu nanoseconds have elapsed." (MClock.elapsed_ns mclock));
+      Logs.app (fun m ->
+          m "At the stroke, the time will be %a \x07 *BEEP*"
+            (Ptime.pp_human ?tz_offset_s:tz ())
+            current_time);
+      Time.sleep_ns (Duration.of_sec 1) >>= fun () -> speak pclock mclock ()
     in
     speak pclock mclock ()
 end

--- a/device-usage/conduit_server/config.ml
+++ b/device-usage/conduit_server/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/device-usage/disk-lottery/config.ml
+++ b/device-usage/disk-lottery/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let runtime_args =

--- a/device-usage/http-fetch/config.ml
+++ b/device-usage/http-fetch/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.uri" ]

--- a/device-usage/http-fetch/unikernel.ml
+++ b/device-usage/http-fetch/unikernel.ml
@@ -1,24 +1,19 @@
 open Lwt.Infix
-open Printf
 open Cmdliner
 
 let uri =
   let doc = Arg.info ~doc:"URL to fetch" [ "uri" ] in
   Arg.(value & opt string "https://mirage.io" doc)
 
-let red fmt = sprintf ("\027[31m" ^^ fmt ^^ "\027[m")
-let green fmt = sprintf ("\027[32m" ^^ fmt ^^ "\027[m")
-let yellow fmt = sprintf ("\027[33m" ^^ fmt ^^ "\027[m")
-let blue fmt = sprintf ("\027[36m" ^^ fmt ^^ "\027[m")
-
 module Client (Client : Cohttp_lwt.S.Client) = struct
   let http_fetch ctx uri =
     Fmt.pr "Fetching %a with Cohttp\n" Uri.pp uri;
     Client.get ~ctx uri >>= fun (response, body) ->
     Cohttp_lwt.Body.to_string body >|= fun body ->
-    Fmt.pr "%a\n" Sexplib.Sexp.pp_hum (Cohttp.Response.sexp_of_t response);
-    Fmt.pr "Received body length: %d\n" (String.length body);
-    Fmt.pr "Cohttp fetch done\n------------\n"
+    Logs.app (fun m ->
+        m "%a" Sexplib.Sexp.pp_hum (Cohttp.Response.sexp_of_t response));
+    Logs.app (fun m -> m "Received body length: %d\n" (String.length body));
+    Logs.app (fun m -> m "Cohttp fetch done\n------------\n")
 
   let start ctx uri =
     let uri = Uri.of_string uri in

--- a/device-usage/kv_ro/config.ml
+++ b/device-usage/kv_ro/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let disk = generic_kv_ro "t"

--- a/device-usage/littlefs/config.ml
+++ b/device-usage/littlefs/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.5.0 *)
 open Mirage
 
 let unikernel =

--- a/device-usage/network/config.ml
+++ b/device-usage/network/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.port" ]

--- a/device-usage/pgx/config.ml
+++ b/device-usage/pgx/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let setup = runtime_arg ~pos:__POS__ "Unikernel.setup"

--- a/device-usage/ping6/config.ml
+++ b/device-usage/ping6/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/device-usage/prng/config.ml
+++ b/device-usage/prng/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let packages =

--- a/tutorial/app_info/config.ml
+++ b/tutorial/app_info/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/hello-key/config.ml
+++ b/tutorial/hello-key/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 & < 4.6.0 *)
 open Mirage
 
 let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.hello" ]

--- a/tutorial/hello/config.ml
+++ b/tutorial/hello/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/lwt/echo_server/config.ml
+++ b/tutorial/lwt/echo_server/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/lwt/heads1/config.ml
+++ b/tutorial/lwt/heads1/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/lwt/heads2/config.ml
+++ b/tutorial/lwt/heads2/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/lwt/timeout1/config.ml
+++ b/tutorial/lwt/timeout1/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/lwt/timeout2/config.ml
+++ b/tutorial/lwt/timeout2/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 open Mirage
 
 let main =

--- a/tutorial/noop/config.ml
+++ b/tutorial/noop/config.ml
@@ -1,1 +1,2 @@
+(* mirage >= 4.4.0 & < 4.6.0 *)
 let () = Mirage.register "noop" []


### PR DESCRIPTION
The purpose is to render nice error messages to users: instead of some config.ml OCaml error, a message is printed that this unikernel is not compatible with the installed version of mirage, and please upgrade/downgrade.

I also took the liberty to cleanup some of the example unikernels in terms of (a) using Duration (b) using Logs ~~(c) a line break after the bind operator (>>=)~~

This superseeds #338