### PR TITLE
Update website in opam file

### DIFF
--- a/mirage-skeleton.opam
+++ b/mirage-skeleton.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer:   "The MirageOS team"
 authors:      "The MirageOS team"
 
-homepage:     "http://www.openmirage.org/"
+homepage:     "http://www.mirageos.org/"
 bug-reports:  "https://github.com/mirage/mirage-skeleton/issues/"
 dev-repo:     "git+https://github.com/mirage/mirage-skeleton.git"
 tags:         ["org:mirage" "org:xapi-project"]


### PR DESCRIPTION
Openmirage.org seems to not respond. Mirage.io is in a precarious situation with .io, so use mirageos.org.